### PR TITLE
Add graceful shutdown of Claude sessions on app exit

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -156,6 +156,13 @@ func New(cfg *config.Config, version string) *Model {
 	return m
 }
 
+// Close gracefully shuts down all Claude sessions and releases resources.
+// This should be called when the application is exiting.
+func (m *Model) Close() {
+	logger.Log("App: Closing and shutting down all sessions")
+	m.sessionMgr.Shutdown()
+}
+
 // State helper methods
 
 // IsIdle returns true if the app is ready for user input

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -310,3 +310,16 @@ func (sm *SessionManager) AddAllowedTool(sessionID string, tool string) {
 func (sm *SessionManager) SetRunner(sessionID string, runner *claude.Runner) {
 	sm.runners[sessionID] = runner
 }
+
+// Shutdown stops all runners gracefully. This should be called when the
+// application is exiting to ensure all Claude CLI processes are terminated
+// and resources are cleaned up.
+func (sm *SessionManager) Shutdown() {
+	logger.Log("SessionManager: Shutting down all runners (%d total)", len(sm.runners))
+	for sessionID, runner := range sm.runners {
+		logger.Log("SessionManager: Stopping runner for session %s", sessionID)
+		runner.Stop()
+	}
+	sm.runners = make(map[string]*claude.Runner)
+	logger.Log("SessionManager: Shutdown complete")
+}

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ For more information, visit: https://github.com/zhubert/plural
 
 	// Create and run the app
 	m := app.New(cfg, version)
+	defer m.Close() // Gracefully shut down all Claude sessions on exit
 	p := tea.NewProgram(m)
 
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
## Summary
Ensures all Claude CLI processes are properly terminated when the application exits, preventing orphaned processes.

## Changes
- Add `Close()` method to `Model` that triggers graceful shutdown
- Add `Shutdown()` method to `SessionManager` that stops all cached runners
- Call `Close()` via defer in main.go when the program exits

## Test plan
- Run `./plural` and create one or more sessions with active Claude conversations
- Exit the app with `q` or Ctrl+C
- Verify no orphaned Claude processes remain: `ps aux | grep claude`
- Check `/tmp/plural-debug.log` for shutdown log messages