### PR TITLE
Fix duplicate user message in parallel session creation

### DIFF
--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -952,11 +952,12 @@ func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Mod
 			m.sidebar.SelectSession(firstSession.ID)
 			m.selectSession(firstSession)
 
-			// Update UI for the active session
+			// Update UI for the active session - the user message is already in the runner's
+			// message history (added by SendContent) and selectSession sets the chat messages
+			// from the runner, so we don't need to add it again here
 			if m.claudeRunner != nil {
 				startTime, _ := m.sessionState().GetWaitStart(firstSession.ID)
 				m.chat.SetWaitingWithStart(true, startTime)
-				m.chat.AddUserMessage(createdSessions[0].OptionPrompt)
 			}
 		}
 


### PR DESCRIPTION
## Summary
Fixes a bug where the user's message was displayed twice when creating parallel sessions via the "Explore options" feature.

## Changes
- Remove redundant `AddUserMessage` call in `createParallelSessions` since the message is already present in the runner's message history from `SendContent` and is loaded by `selectSession`

## Test plan
- Create a session and send a message that causes Claude to offer multiple options
- Press Ctrl+P to explore options in parallel
- Select one or more options and confirm
- Verify the user message appears only once in the chat view for each created session