### PR TITLE
Add "Fixes #N" to PR body when session created from GitHub issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Import GitHub issues directly into new sessions:
 5. **Create sessions**: Press Enter to create a new session for each selected issue
 6. **Auto-start**: Claude automatically receives the issue context and begins working
 
-Each issue becomes a session with branch name `issue-{number}`.
+Each issue becomes a session with branch name `issue-{number}`. The issue number is stored in the session and when a PR is created, "Fixes #N" is automatically added to the PR body, which will close the issue when the PR is merged.
 
 ### Dependencies
 

--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -263,7 +263,7 @@ func (m *Model) handleMergeModal(key string, msg tea.KeyPressMsg, state *ui.Merg
 		case MergeTypePR:
 			logger.Log("App: Creating PR for branch %s (no uncommitted changes)", sess.Branch)
 			m.chat.AppendStreaming("Creating PR for " + sess.Branch + "...\n\n")
-			m.sessionState().StartMerge(sess.ID, git.CreatePR(ctx, sess.RepoPath, sess.WorkTree, sess.Branch, ""), cancel, MergeTypePR)
+			m.sessionState().StartMerge(sess.ID, git.CreatePR(ctx, sess.RepoPath, sess.WorkTree, sess.Branch, "", sess.IssueNumber), cancel, MergeTypePR)
 		case MergeTypePush:
 			logger.Log("App: Pushing updates for branch %s (no uncommitted changes)", sess.Branch)
 			m.chat.AppendStreaming("Pushing updates to " + sess.Branch + "...\n\n")
@@ -396,7 +396,7 @@ func (m *Model) handleEditCommitModal(key string, msg tea.KeyPressMsg, state *ui
 		case MergeTypePR:
 			logger.Log("App: Creating PR for branch %s with user-edited commit message", sess.Branch)
 			m.chat.AppendStreaming("Creating PR for " + sess.Branch + "...\n\n")
-			m.sessionState().StartMerge(sess.ID, git.CreatePR(ctx, sess.RepoPath, sess.WorkTree, sess.Branch, commitMsg), cancel, MergeTypePR)
+			m.sessionState().StartMerge(sess.ID, git.CreatePR(ctx, sess.RepoPath, sess.WorkTree, sess.Branch, commitMsg, sess.IssueNumber), cancel, MergeTypePR)
 		case MergeTypePush:
 			logger.Log("App: Pushing updates for branch %s with user-edited commit message", sess.Branch)
 			m.chat.AppendStreaming("Pushing updates to " + sess.Branch + "...\n\n")
@@ -725,6 +725,9 @@ func (m *Model) createSessionsFromIssues(repoPath string, issues []ui.IssueItem)
 			logger.Log("App: Failed to create session for issue #%d: %v", issue.Number, err)
 			continue
 		}
+
+		// Store the issue number so we can reference it in the PR
+		sess.IssueNumber = issue.Number
 
 		// Create initial message with issue context
 		initialMsg := fmt.Sprintf("GitHub Issue #%d: %s\n\n%s\n\n---\nPlease help me work on this issue.",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Session struct {
 	PRCreated      bool      `json:"pr_created,omitempty"`       // Whether a PR has been created for this session
 	ParentID       string    `json:"parent_id,omitempty"`        // ID of parent session if this is a fork
 	MergedToParent bool      `json:"merged_to_parent,omitempty"` // Whether session has been merged back to its parent (locks the session)
+	IssueNumber    int       `json:"issue_number,omitempty"`     // GitHub issue number if session was created from an issue
 }
 
 // MCPServer represents an MCP server configuration

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -283,7 +283,7 @@ func TestCreatePR_NoGh(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	ch := CreatePR(ctx, repoPath, repoPath, "test-branch", "")
+	ch := CreatePR(ctx, repoPath, repoPath, "test-branch", "", 0)
 
 	var hadError bool
 	for result := range ch {
@@ -590,7 +590,7 @@ func TestCreatePR_WithProvidedCommitMessage(t *testing.T) {
 	defer cancel()
 
 	// CreatePR will fail without a real remote, but we can verify it tries
-	ch := CreatePR(ctx, repoPath, repoPath, "feature-pr-msg", "Custom PR commit")
+	ch := CreatePR(ctx, repoPath, repoPath, "feature-pr-msg", "Custom PR commit", 0)
 
 	// Drain channel - expect an error since no remote
 	for range ch {
@@ -717,7 +717,7 @@ func TestCreatePR_Cancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	ch := CreatePR(ctx, repoPath, repoPath, "pr-cancel-test", "")
+	ch := CreatePR(ctx, repoPath, repoPath, "pr-cancel-test", "", 0)
 
 	// Drain channel - should not hang
 	for range ch {


### PR DESCRIPTION
## Summary
When a session is created from a GitHub issue import, the PR body now automatically includes "Fixes #N" which will close the associated issue when the PR is merged.

## Changes
- Store the GitHub issue number in the session when creating sessions from issues
- Add `IssueNumber` field to the Session config struct
- Pass issue number through to `CreatePR` and `GeneratePRTitleAndBody` functions
- Append "Fixes #N" to the generated PR body when an issue number is present
- Update CLAUDE.md to document this behavior

## Test plan
- Import a GitHub issue using `i` to create a new session
- Make changes and create a PR using `m`
- Verify the PR body contains "Fixes #N" referencing the original issue
- Verify PRs created from sessions not originating from issues do not have the fixes line

Fixes #6