### PR TITLE
Add Science Fiction theme with red/black color scheme

### DIFF
--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -74,13 +74,14 @@ type ThemeName string
 
 // Available theme names
 const (
-	ThemeDarkPurple ThemeName = "dark-purple"
-	ThemeNord       ThemeName = "nord"
-	ThemeDracula    ThemeName = "dracula"
-	ThemeGruvbox    ThemeName = "gruvbox"
-	ThemeTokyoNight ThemeName = "tokyo-night"
-	ThemeCatppuccin ThemeName = "catppuccin"
-	ThemeLight      ThemeName = "light"
+	ThemeDarkPurple    ThemeName = "dark-purple"
+	ThemeNord          ThemeName = "nord"
+	ThemeDracula       ThemeName = "dracula"
+	ThemeGruvbox       ThemeName = "gruvbox"
+	ThemeTokyoNight    ThemeName = "tokyo-night"
+	ThemeCatppuccin    ThemeName = "catppuccin"
+	ThemeScienceFiction ThemeName = "science-fiction"
+	ThemeLight         ThemeName = "light"
 )
 
 // DefaultTheme is the default theme name
@@ -250,6 +251,35 @@ var BuiltinThemes = map[ThemeName]Theme{
 		MarkdownLink:     "#89DCEB",
 		MarkdownListItem: "#CBA6F7",
 	},
+	ThemeScienceFiction: {
+		Name:             "Science Fiction",
+		Primary:          "#E50914",
+		Secondary:        "#8B0000",
+		Bg:               "#0A0A0A",
+		BgDark:           "#000000",
+		BgSelected:       "#2D0A0A",
+		Text:             "#E8E8E8",
+		TextMuted:        "#666666",
+		TextInverse:      "#0A0A0A",
+		User:             "#FF4444",
+		Assistant:        "#CC0000",
+		Warning:          "#FF6600",
+		Error:            "#FF0000",
+		Info:             "#AA0000",
+		Border:           "#330000",
+		BorderFocus:      "#E50914",
+		DiffAdded:        "#00AA00",
+		DiffRemoved:      "#FF4444",
+		DiffHeader:       "#E50914",
+		DiffHunk:         "#8B0000",
+		MarkdownH1:       "#E50914",
+		MarkdownH2:       "#CC0000",
+		MarkdownH3:       "#AA0000",
+		MarkdownCode:     "#FF6666",
+		MarkdownCodeBg:   "#1A0000",
+		MarkdownLink:     "#FF4444",
+		MarkdownListItem: "#E50914",
+	},
 	ThemeLight: {
 		Name:             "Light",
 		Primary:          "#6366F1",
@@ -290,6 +320,7 @@ func ThemeNames() []ThemeName {
 		ThemeGruvbox,
 		ThemeTokyoNight,
 		ThemeCatppuccin,
+		ThemeScienceFiction,
 		ThemeLight,
 	}
 }


### PR DESCRIPTION
## Summary
Adds a new "Science Fiction" theme featuring a dark red and black color palette inspired by sci-fi aesthetics.

## Changes
- Add `ThemeScienceFiction` constant to available theme names
- Define complete theme color scheme with red primary (#E50914), dark backgrounds, and coordinated accent colors
- Add theme to the `ThemeNames()` list for theme selection

## Test plan
- Run `go build` to verify compilation
- Launch the application and open Settings (`,`)
- Cycle through themes to find "Science Fiction"
- Verify the red/black color scheme displays correctly across all UI elements
- Test in both sidebar and chat views to ensure readability

Fixes #12