### PR TITLE
Add file-by-file navigation to view changes mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,19 @@ Import GitHub issues directly into new sessions:
 
 Each issue becomes a session with branch name `issue-{number}`. The issue number is stored in the session and when a PR is created, "Fixes #N" is automatically added to the PR body, which will close the issue when the PR is merged.
 
+### View Changes (Pre-Merge Diff Review)
+
+Review file diffs before merging with a file-by-file navigator:
+
+1. **Press `v`** when a session is selected in the sidebar
+2. **Two-pane layout**: Left pane shows file list, right pane shows diff content
+3. **Navigate files**: Use ↑/↓ to select different files in the list
+4. **Switch panes**: Use ←/→ or h/l to switch between file list and diff pane
+5. **Scroll diff**: Use j/k or PgUp/PgDn when in the diff pane
+6. **Exit**: Press Esc or q to close
+
+Each file shows its status code (M=modified, A=added, D=deleted) and the diff is syntax-highlighted with additions in green and deletions in red.
+
 ### Message Search
 
 Search within conversation history:

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	"github.com/zhubert/plural/internal/git"
 	"github.com/zhubert/plural/internal/mcp"
 	"github.com/zhubert/plural/internal/ui"
 )
@@ -750,7 +751,11 @@ func TestIntegration_ViewChanges_EnterAndExit(t *testing.T) {
 	}
 
 	// Enter view changes mode
-	m.chat.EnterViewChangesMode("test changes content")
+	m.chat.EnterViewChangesMode([]git.FileDiff{{
+		Filename: "test.go",
+		Status:   "M",
+		Diff:     "test changes content",
+	}})
 	if !m.chat.IsInViewChangesMode() {
 		t.Error("Should be in view changes mode")
 	}

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -375,24 +375,23 @@ func shortcutViewChanges(m *Model) (tea.Model, tea.Cmd) {
 	}
 	// Get worktree status and display it in view changes overlay
 	status, err := git.GetWorktreeStatus(sess.WorkTree)
-	var content string
+	var files []git.FileDiff
 	if err != nil {
-		content = fmt.Sprintf("[Error getting status: %v]\n", err)
+		files = []git.FileDiff{{
+			Filename: "Error",
+			Status:   "!",
+			Diff:     fmt.Sprintf("Error getting status: %v", err),
+		}}
 	} else if !status.HasChanges {
-		content = "No uncommitted changes in this session."
+		files = []git.FileDiff{{
+			Filename: "No changes",
+			Status:   " ",
+			Diff:     "No uncommitted changes in this session.",
+		}}
 	} else {
-		var sb strings.Builder
-		fmt.Fprintf(&sb, "Uncommitted changes (%s):\n\n", status.Summary)
-		for _, file := range status.Files {
-			fmt.Fprintf(&sb, "  - %s\n", file)
-		}
-		if status.Diff != "" {
-			sb.WriteString("\n--- Diff ---\n")
-			sb.WriteString(ui.HighlightDiff(status.Diff))
-		}
-		content = sb.String()
+		files = status.FileDiffs
 	}
-	m.chat.EnterViewChangesMode(content)
+	m.chat.EnterViewChangesMode(files)
 	return m, nil
 }
 

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -74,9 +74,10 @@ func (f *Footer) View() string {
 	// Show view-changes-specific shortcuts when in view changes mode
 	if f.viewChangesMode {
 		viewChangesBindings := []KeyBinding{
-			{Key: "esc/q/v", Desc: "close"},
-			{Key: "↑/↓/j/k", Desc: "scroll"},
-			{Key: "pgup/dn", Desc: "page"},
+			{Key: "←/→", Desc: "switch pane"},
+			{Key: "↑/↓", Desc: "select file"},
+			{Key: "j/k", Desc: "scroll diff"},
+			{Key: "esc/q", Desc: "close"},
 		}
 		for _, b := range viewChangesBindings {
 			key := FooterKeyStyle.Render(b.Key)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -251,4 +251,9 @@ var (
 
 	DiffHunkStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#C084FC")) // Purple for @@ hunk markers
+
+	// View changes file list selection style
+	ViewChangesSelectedStyle = lipgloss.NewStyle().
+					Background(lipgloss.Color("#3B82F6")). // Blue background
+					Foreground(lipgloss.Color("#FFFFFF"))  // White text
 )


### PR DESCRIPTION
## Summary
Enhances the view changes mode (`v` shortcut) with a two-pane file navigator, allowing users to browse and review individual file diffs before merging instead of viewing one large combined diff.

## Changes
- Add split-pane layout with file list (left) and diff content (right)
- Implement file-by-file navigation using ↑/↓ arrow keys
- Add pane switching with ←/→ or h/l keys
- Parse combined git diff into per-file chunks with `FileDiff` struct
- Show file status codes (M=modified, A=added, D=deleted) in the file list
- Highlight selected file and focused pane with visual indicators
- Update footer to show new navigation shortcuts

## Test plan
- Run `go test ./...` to verify tests pass
- Launch the app and create a session with uncommitted changes
- Press `v` to enter view changes mode
- Verify two-pane layout appears with file list on left
- Test ↑/↓ navigation between files in the list
- Test ←/→ to switch focus between file list and diff pane
- Test j/k scrolling when diff pane is focused
- Verify Esc or q closes the view
- Test with no changes, single file, and multiple files

Fixes #13