### PR TITLE
Add UI animations for focus transitions and response completion

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -497,20 +497,29 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-func (m *Model) toggleFocus() {
+func (m *Model) toggleFocus() tea.Cmd {
+	var cmds []tea.Cmd
 	if m.focus == FocusSidebar {
 		// Only allow switching to chat if there's an active session
 		if m.activeSession == nil {
-			return
+			return nil
 		}
 		m.focus = FocusChat
 		m.sidebar.SetFocused(false)
 		m.chat.SetFocused(true)
+		// Start focus pulse on chat
+		cmds = append(cmds, m.chat.StartFocusPulse())
 	} else {
 		m.focus = FocusSidebar
 		m.sidebar.SetFocused(true)
 		m.chat.SetFocused(false)
+		// Start focus pulse on sidebar
+		cmds = append(cmds, m.sidebar.StartFocusPulse())
 	}
+	if len(cmds) > 0 {
+		return tea.Batch(cmds...)
+	}
+	return nil
 }
 
 func (m *Model) showMCPServersModal() {

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -316,8 +316,8 @@ func (m *Model) hasSessionInUseError() bool {
 // =============================================================================
 
 func shortcutToggleFocus(m *Model) (tea.Model, tea.Cmd) {
-	m.toggleFocus()
-	return m, nil
+	cmd := m.toggleFocus()
+	return m, cmd
 }
 
 func shortcutSearch(m *Model) (tea.Model, tea.Cmd) {

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -388,15 +388,17 @@ func TestRenderSpinner(t *testing.T) {
 	verbs := []string{"Thinking", "Pondering", "Analyzing"}
 	for _, verb := range verbs {
 		for i := 0; i < len(spinnerFrames); i++ {
-			result := renderSpinner(verb, i)
-			if result == "" {
-				t.Errorf("renderSpinner(%q, %d) returned empty string", verb, i)
-			}
-			if !strings.Contains(result, verb) {
-				t.Errorf("renderSpinner(%q, %d) = %q, should contain verb", verb, i, result)
-			}
-			if !strings.Contains(result, "...") {
-				t.Errorf("renderSpinner(%q, %d) = %q, should contain ellipsis", verb, i, result)
+			for w := 0; w < len(waveFrames); w++ {
+				result := renderSpinner(verb, i, w)
+				if result == "" {
+					t.Errorf("renderSpinner(%q, %d, %d) returned empty string", verb, i, w)
+				}
+				if !strings.Contains(result, verb) {
+					t.Errorf("renderSpinner(%q, %d, %d) = %q, should contain verb", verb, i, w, result)
+				}
+				if !strings.Contains(result, "...") {
+					t.Errorf("renderSpinner(%q, %d, %d) = %q, should contain ellipsis", verb, i, w, result)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Adds subtle animations to improve visual feedback in the TUI, including focus pulse animations when switching between sidebar and chat panels, a completion flash animation when Claude finishes responding, and a wave animation during streaming.

## Changes
- Add focus pulse animation (brief bright purple border flash) when Tab switches focus between panels
- Add completion flash animation showing a green checkmark when Claude finishes streaming
- Add wave animation (`·•○•·`) alongside the existing spinner during streaming
- Add selection fade animation when navigating sessions in the sidebar
- Refactor `toggleFocus()` to return `tea.Cmd` to support animation commands

## Test plan
- Run `go test ./...` to verify existing tests pass (including updated `renderSpinner` tests)
- Build and run the app: `go generate ./... && go run .`
- Create a session and send a message - observe the wave animation while streaming
- When Claude finishes responding, observe the green checkmark flash
- Press Tab to switch focus between sidebar and chat - observe the brief purple border pulse
- Navigate up/down in the sidebar - observe the selection fade-in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)