### PR TITLE
Fix race conditions in permission/question channel handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1197,6 +1197,10 @@ func (m *Model) listenForSessionPermission(sessionID string, runner *claude.Runn
 	}
 
 	ch := runner.PermissionRequestChan()
+	if ch == nil {
+		// Runner has been stopped, don't create a goroutine that would block forever
+		return nil
+	}
 	return func() tea.Msg {
 		req, ok := <-ch
 		if !ok {
@@ -1213,6 +1217,10 @@ func (m *Model) listenForSessionQuestion(sessionID string, runner *claude.Runner
 	}
 
 	ch := runner.QuestionRequestChan()
+	if ch == nil {
+		// Runner has been stopped, don't create a goroutine that would block forever
+		return nil
+	}
 	return func() tea.Msg {
 		req, ok := <-ch
 		if !ok {


### PR DESCRIPTION
## Summary
Fixes race conditions that could cause deadlocks or panics when sending permission/question responses to stopped runners.

## Changes
- Add nil checks for permission and question request channels before creating listener goroutines
- Make `SendPermissionResponse` and `SendQuestionResponse` safe to call on stopped runners
- Use non-blocking sends with mutex protection to prevent deadlocks when channels are closed
- Remove unnecessary goroutine watching for context cancellation in `SendContent`

## Test plan
- Run the application and create/delete sessions rapidly while permission prompts are active
- Stop a session while a permission or question prompt is pending
- Verify no panics or hangs occur during session cleanup
- Check debug logs for "called on stopped runner" messages to confirm graceful handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)