### PR TITLE
Remove unused code: sendKeys, ChunkTypeStatus, italicPattern, NewHelpState

### DIFF
--- a/internal/app/testutil_test.go
+++ b/internal/app/testutil_test.go
@@ -121,14 +121,6 @@ func sendKey(m *Model, key string) *Model {
 	return result.(*Model)
 }
 
-// sendKeys sends multiple key presses to the model in sequence.
-func sendKeys(m *Model, keys ...string) *Model {
-	for _, key := range keys {
-		m = sendKey(m, key)
-	}
-	return m
-}
-
 // typeText simulates typing a string by sending individual character key presses.
 func typeText(m *Model, text string) *Model {
 	for _, ch := range text {

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -327,7 +327,6 @@ const (
 	ChunkTypeText       ChunkType = "text"        // Regular text content
 	ChunkTypeToolUse    ChunkType = "tool_use"    // Claude is calling a tool
 	ChunkTypeToolResult ChunkType = "tool_result" // Tool execution result
-	ChunkTypeStatus     ChunkType = "status"      // Status message (init, result)
 )
 
 // ResponseChunk represents a chunk of streaming response

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -582,9 +582,6 @@ func TestChunkTypes(t *testing.T) {
 	if ChunkTypeToolResult != "tool_result" {
 		t.Errorf("ChunkTypeToolResult = %q, want 'tool_result'", ChunkTypeToolResult)
 	}
-	if ChunkTypeStatus != "status" {
-		t.Errorf("ChunkTypeStatus = %q, want 'status'", ChunkTypeStatus)
-	}
 }
 
 func TestParseStreamMessage_EmptyText(t *testing.T) {

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -40,7 +40,6 @@ func stripOptionsTags(content string) string {
 // Compiled regex patterns for markdown parsing
 var (
 	boldPattern       = regexp.MustCompile(`\*\*([^*]+)\*\*`)
-	italicPattern     = regexp.MustCompile(`(?:^|[^*])\*([^*]+)\*(?:[^*]|$)`)
 	underscoreItalic  = regexp.MustCompile(`(?:^|[^a-zA-Z0-9_])_([^_]+)_(?:[^a-zA-Z0-9_]|$)`)
 	inlineCodePattern = regexp.MustCompile("`([^`]+)`")
 	linkPattern       = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -57,7 +57,6 @@ var (
 	NewChangelogState          = modals.NewChangelogState
 	NewSettingsState           = modals.NewSettingsState
 	NewImportIssuesState       = modals.NewImportIssuesState
-	NewHelpState               = modals.NewHelpState
 	NewHelpStateFromSections   = modals.NewHelpStateFromSections
 	NewExploreOptionsState     = modals.NewExploreOptionsState
 	NewSearchMessagesState     = modals.NewSearchMessagesState


### PR DESCRIPTION
## Summary
Clean up unused code identified during codebase maintenance.

## Changes
- Remove `sendKeys` helper function from test utilities (unused)
- Remove `ChunkTypeStatus` constant from claude package (unused)
- Remove `italicPattern` regex from chat.go (unused)
- Remove `NewHelpState` re-export from modal.go (unused, `NewHelpStateFromSections` is used instead)

## Test plan
- Run `go test ./...` to verify all tests pass
- Run `go build -o plural .` to verify the build succeeds