### PR TITLE
Fix incorrect keyboard shortcut in no-session help message

### DIFF
--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -629,7 +629,7 @@ func (c *Chat) renderNoSessionMessage() string {
 	sb.WriteString(msgStyle.Render(" to create a new session"))
 	sb.WriteString("\n")
 	sb.WriteString(msgStyle.Render("  • Press "))
-	sb.WriteString(keyStyle.Render("r"))
+	sb.WriteString(keyStyle.Render("a"))
 	sb.WriteString(msgStyle.Render(" to add a repository first"))
 	return sb.String()
 }


### PR DESCRIPTION
## Summary
Corrects the keyboard shortcut displayed in the help message shown when no session is active.

## Changes
- Fixed the "add a repository" shortcut from `r` to `a` in the no-session message

## Test plan
- Run the application without any sessions active
- Verify the help message shows "Press `a` to add a repository first"
- Confirm pressing `a` opens the add repository dialog

Fixes #25