### PR TITLE
Add Tab path completion to Add Repository modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,16 @@ Merge types enum: `MergeTypeMerge` (to main), `MergeTypePR` (create PR), `MergeT
 
 Issue number stored in session. When PR created from issue session, "Fixes #N" auto-added to PR body. Branch naming: `issue-{number}`.
 
+### Path Auto-Completion
+
+The Add Repository modal (`a` key) supports Tab completion for paths:
+
+- **PathCompleter** (`internal/ui/modals/completion.go`): Handles filesystem path auto-completion
+- Expands `~` to home directory
+- Shows completion options when multiple matches exist
+- Hidden files only shown when typing `.` prefix
+- Use up/down to navigate options, Tab/Enter to select
+
 ---
 
 ## Dependencies

--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -69,6 +69,13 @@ func (m *Model) handleModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // handleAddRepoModal handles key events for the Add Repository modal.
 func (m *Model) handleAddRepoModal(key string, msg tea.KeyPressMsg, state *ui.AddRepoState) (tea.Model, tea.Cmd) {
+	// If showing completion options, forward Enter to the modal to select the option
+	if state.IsShowingOptions() && key == "enter" {
+		modal, cmd := m.modal.Update(msg)
+		m.modal = modal
+		return m, cmd
+	}
+
 	switch key {
 	case "esc":
 		m.modal.Hide()

--- a/internal/ui/modals/completion.go
+++ b/internal/ui/modals/completion.go
@@ -1,0 +1,212 @@
+package modals
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PathCompleter handles filesystem path auto-completion.
+type PathCompleter struct {
+	completions []string // Available completions for current prefix
+	index       int      // Current selection index (-1 means no selection)
+	prefix      string   // The prefix used to generate completions
+}
+
+// NewPathCompleter creates a new path completer.
+func NewPathCompleter() *PathCompleter {
+	return &PathCompleter{
+		completions: nil,
+		index:       -1,
+		prefix:      "",
+	}
+}
+
+// Complete attempts to complete the given path.
+// Returns the completed path and whether completion was successful.
+// On first tab press, it completes to common prefix or first match.
+// On subsequent tab presses with same prefix, it cycles through matches.
+func (pc *PathCompleter) Complete(path string) (string, bool) {
+	// Expand ~ to home directory
+	expandedPath := expandHome(path)
+
+	// If path changed from last completion, regenerate completions
+	if expandedPath != pc.prefix || pc.completions == nil {
+		pc.generateCompletions(expandedPath)
+		pc.prefix = expandedPath
+	}
+
+	if len(pc.completions) == 0 {
+		return path, false
+	}
+
+	// Single completion - just return it
+	if len(pc.completions) == 1 {
+		return pc.completions[0], true
+	}
+
+	// Multiple completions - find common prefix first time, then cycle
+	if pc.index == -1 {
+		// First tab - try to complete to common prefix
+		common := commonPrefix(pc.completions)
+		if common != expandedPath && common != "" {
+			// Reset so next tab cycles through options
+			pc.prefix = common
+			pc.index = -1
+			return common, true
+		}
+		// Common prefix is same as input, start cycling
+		pc.index = 0
+		return pc.completions[0], true
+	}
+
+	// Cycle through completions
+	pc.index = (pc.index + 1) % len(pc.completions)
+	return pc.completions[pc.index], true
+}
+
+// Reset clears the current completion state.
+// Call this when the input changes (not via tab completion).
+func (pc *PathCompleter) Reset() {
+	pc.completions = nil
+	pc.index = -1
+	pc.prefix = ""
+}
+
+// GetCompletions returns the current list of completions.
+func (pc *PathCompleter) GetCompletions() []string {
+	return pc.completions
+}
+
+// GetIndex returns the current selection index.
+func (pc *PathCompleter) GetIndex() int {
+	return pc.index
+}
+
+// GenerateCompletions populates the completions for the given path.
+// This is the public version that expands home directory.
+func (pc *PathCompleter) GenerateCompletions(path string) {
+	expandedPath := expandHome(path)
+	pc.generateCompletions(expandedPath)
+	pc.prefix = expandedPath
+}
+
+// GetCommonPrefix returns the longest common prefix of all completions.
+func (pc *PathCompleter) GetCommonPrefix() string {
+	return commonPrefix(pc.completions)
+}
+
+// generateCompletions populates the completions slice for the given path.
+func (pc *PathCompleter) generateCompletions(path string) {
+	pc.completions = nil
+	pc.index = -1
+
+	if path == "" {
+		path = "/"
+	}
+
+	var dir, prefix string
+
+	// Check if path exists and is a directory
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		// Path is an existing directory
+		if strings.HasSuffix(path, "/") || path == "/" {
+			// User typed trailing slash, list contents
+			dir = path
+			prefix = ""
+		} else {
+			// No trailing slash - could mean they want to complete the name or go into dir
+			// Add trailing slash to complete the directory
+			pc.completions = []string{path + "/"}
+			return
+		}
+	} else {
+		// Path doesn't exist or is a file - get parent directory and filename prefix
+		dir = filepath.Dir(path)
+		prefix = filepath.Base(path)
+		if path == prefix {
+			// No directory component, use current dir
+			dir = "."
+		}
+	}
+
+	// Read directory contents
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	// Filter entries that match prefix and are directories
+	for _, entry := range entries {
+		name := entry.Name()
+		// Skip hidden files unless prefix starts with .
+		if strings.HasPrefix(name, ".") && !strings.HasPrefix(prefix, ".") {
+			continue
+		}
+
+		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
+			fullPath := filepath.Join(dir, name)
+			if entry.IsDir() {
+				fullPath += "/"
+			}
+			pc.completions = append(pc.completions, fullPath)
+		}
+	}
+
+	// Sort completions
+	sort.Strings(pc.completions)
+}
+
+// expandHome expands ~ to the user's home directory.
+func expandHome(path string) string {
+	if path == "" {
+		return ""
+	}
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// commonPrefix finds the longest common prefix among all strings.
+func commonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	if len(strs) == 1 {
+		return strs[0]
+	}
+
+	// Find shortest string
+	shortest := strs[0]
+	for _, s := range strs[1:] {
+		if len(s) < len(shortest) {
+			shortest = s
+		}
+	}
+
+	// Find common prefix
+	for i := 0; i < len(shortest); i++ {
+		char := shortest[i]
+		for _, s := range strs {
+			if s[i] != char {
+				return shortest[:i]
+			}
+		}
+	}
+
+	return shortest
+}

--- a/internal/ui/modals/completion_test.go
+++ b/internal/ui/modals/completion_test.go
@@ -1,0 +1,253 @@
+package modals
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("Cannot get home directory")
+	}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"~", home},
+		{"~/Documents", filepath.Join(home, "Documents")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := expandHome(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandHome(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommonPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{"empty", []string{}, ""},
+		{"single", []string{"hello"}, "hello"},
+		{"common", []string{"hello", "help", "helicopter"}, "hel"},
+		{"no common", []string{"abc", "xyz"}, ""},
+		{"full match", []string{"same", "same"}, "same"},
+		{"partial paths", []string{"/usr/local/bin", "/usr/local/lib"}, "/usr/local/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := commonPrefix(tt.input)
+			if result != tt.expected {
+				t.Errorf("commonPrefix(%v) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPathCompleter_Complete(t *testing.T) {
+	// Create a temporary directory structure for testing
+	tmpDir, err := os.MkdirTemp("", "completion_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create test directories
+	testDirs := []string{
+		"projects",
+		"projects/app1",
+		"projects/app2",
+		"pictures",
+		"documents",
+	}
+	for _, dir := range testDirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a test file (should not appear in directory-only completions)
+	if err := os.WriteFile(filepath.Join(tmpDir, "readme.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("complete directory with common prefix", func(t *testing.T) {
+		pc := NewPathCompleter()
+		// Type "p" in tmpDir - should complete to common prefix of projects/ and pictures/
+		result, ok := pc.Complete(filepath.Join(tmpDir, "p"))
+		if !ok {
+			t.Error("Expected completion to succeed")
+		}
+		// Should get common prefix "p" with completions available
+		expectedPrefix := filepath.Join(tmpDir, "p")
+		if result != expectedPrefix+"ictures/" && result != expectedPrefix+"rojects/" {
+			// First completion should be one of the "p" directories
+			t.Logf("Got result: %s", result)
+		}
+	})
+
+	t.Run("complete unique prefix", func(t *testing.T) {
+		pc := NewPathCompleter()
+		result, ok := pc.Complete(filepath.Join(tmpDir, "doc"))
+		if !ok {
+			t.Error("Expected completion to succeed")
+		}
+		expected := filepath.Join(tmpDir, "documents") + "/"
+		if result != expected {
+			t.Errorf("Got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("complete existing directory adds slash", func(t *testing.T) {
+		pc := NewPathCompleter()
+		result, ok := pc.Complete(filepath.Join(tmpDir, "projects"))
+		if !ok {
+			t.Error("Expected completion to succeed")
+		}
+		expected := filepath.Join(tmpDir, "projects") + "/"
+		if result != expected {
+			t.Errorf("Got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("complete in directory lists subdirs", func(t *testing.T) {
+		pc := NewPathCompleter()
+		result, ok := pc.Complete(filepath.Join(tmpDir, "projects") + "/")
+		if !ok {
+			t.Error("Expected completion to succeed")
+		}
+		// Should complete to app1 or app2 (common prefix is "app")
+		if result != filepath.Join(tmpDir, "projects", "app") {
+			// Or it might return first match
+			t.Logf("Got result: %s", result)
+		}
+	})
+
+	t.Run("no match returns original", func(t *testing.T) {
+		pc := NewPathCompleter()
+		original := filepath.Join(tmpDir, "xyz")
+		result, ok := pc.Complete(original)
+		if ok {
+			t.Error("Expected completion to fail for non-matching prefix")
+		}
+		if result != original {
+			t.Errorf("Got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("cycle through completions", func(t *testing.T) {
+		pc := NewPathCompleter()
+		prefix := filepath.Join(tmpDir, "projects") + "/app"
+
+		// First tab - should complete to common prefix or first match
+		result1, ok := pc.Complete(prefix)
+		if !ok {
+			t.Error("Expected first completion to succeed")
+		}
+
+		// The completer should have the common prefix stored
+		// Complete again with same input to cycle through matches
+		result2, ok := pc.Complete(prefix)
+		if !ok {
+			t.Error("Expected second completion to succeed")
+		}
+
+		// If there are multiple matches, after common prefix, cycling should work
+		completions := pc.GetCompletions()
+		t.Logf("Completions: %v", completions)
+		t.Logf("Result1: %s, Result2: %s", result1, result2)
+
+		// Results may be same if common prefix was returned first
+		// The key behavior is that completions are populated
+		if len(completions) < 2 {
+			t.Error("Expected at least 2 completions for app* pattern")
+		}
+	})
+
+	t.Run("reset clears state", func(t *testing.T) {
+		pc := NewPathCompleter()
+		pc.Complete(filepath.Join(tmpDir, "p"))
+		if len(pc.GetCompletions()) == 0 {
+			t.Error("Expected completions to be populated")
+		}
+
+		pc.Reset()
+		if len(pc.GetCompletions()) != 0 {
+			t.Error("Expected completions to be cleared after reset")
+		}
+		if pc.GetIndex() != -1 {
+			t.Error("Expected index to be reset to -1")
+		}
+	})
+}
+
+func TestPathCompleter_HiddenFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "completion_hidden_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create hidden and non-hidden directories
+	dirs := []string{".hidden", ".config", "visible"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("hidden dirs excluded by default", func(t *testing.T) {
+		pc := NewPathCompleter()
+		pc.Complete(tmpDir + "/")
+
+		completions := pc.GetCompletions()
+		for _, c := range completions {
+			base := filepath.Base(c)
+			if base[0] == '.' {
+				t.Errorf("Hidden directory %q should not be in completions", c)
+			}
+		}
+	})
+
+	t.Run("hidden dirs included when prefix starts with dot", func(t *testing.T) {
+		pc := NewPathCompleter()
+		// Use trailing slash + dot to list hidden files in tmpDir
+		_, ok := pc.Complete(tmpDir + "/.")
+
+		if !ok {
+			t.Error("Expected completion to succeed for hidden files")
+		}
+
+		completions := pc.GetCompletions()
+		if len(completions) == 0 {
+			t.Error("Expected hidden directories to be included")
+		}
+
+		foundHidden := false
+		for _, c := range completions {
+			base := filepath.Base(strings.TrimSuffix(c, "/"))
+			if len(base) > 0 && base[0] == '.' {
+				foundHidden = true
+				break
+			}
+		}
+		if !foundHidden {
+			t.Logf("Completions: %v", completions)
+			t.Error("Expected to find hidden directories when prefix starts with .")
+		}
+	})
+}

--- a/internal/ui/modals/repo.go
+++ b/internal/ui/modals/repo.go
@@ -1,6 +1,8 @@
 package modals
 
 import (
+	"path/filepath"
+
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -11,9 +13,13 @@ import (
 // =============================================================================
 
 type AddRepoState struct {
-	Input         textinput.Model
-	SuggestedRepo string
-	UseSuggested  bool
+	Input            textinput.Model
+	SuggestedRepo    string
+	UseSuggested     bool
+	completer        *PathCompleter // Path auto-completion
+	lastValue        string         // Track input changes to reset completer
+	showingOptions   bool           // Whether we're showing completion options
+	completionIndex  int            // Currently selected completion option
 }
 
 func (*AddRepoState) modalState() {}
@@ -21,10 +27,13 @@ func (*AddRepoState) modalState() {}
 func (s *AddRepoState) Title() string { return "Add Repository" }
 
 func (s *AddRepoState) Help() string {
-	if s.SuggestedRepo != "" {
-		return "up/down to switch, Enter to confirm, Esc to cancel"
+	if s.showingOptions {
+		return "up/down to select, Tab/Enter to confirm, Esc to cancel"
 	}
-	return "Enter the full path to a git repository"
+	if s.SuggestedRepo != "" {
+		return "up/down to switch, Tab to complete path, Enter to confirm, Esc to cancel"
+	}
+	return "Tab to complete path, Enter to confirm, Esc to cancel"
 }
 
 func (s *AddRepoState) Render() string {
@@ -63,29 +72,193 @@ func (s *AddRepoState) Render() string {
 		content = s.Input.View()
 	}
 
+	// Show completion options if available
+	if s.showingOptions {
+		completions := s.completer.GetCompletions()
+		if len(completions) > 0 {
+			optionsLabel := lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				MarginTop(1).
+				Render("Completions:")
+
+			// Render completion options (show basename for cleaner display)
+			options := s.renderCompletionOptions(completions)
+			content = lipgloss.JoinVertical(lipgloss.Left, content, optionsLabel, options)
+		}
+	}
+
 	help := ModalHelpStyle.Render(s.Help())
 
 	return lipgloss.JoinVertical(lipgloss.Left, title, content, help)
 }
 
+// renderCompletionOptions renders the list of completion options with selection indicator
+func (s *AddRepoState) renderCompletionOptions(completions []string) string {
+	maxDisplay := 5 // Show at most 5 options to keep modal compact
+	start := 0
+	if s.completionIndex >= maxDisplay {
+		start = s.completionIndex - maxDisplay + 1
+	}
+	end := start + maxDisplay
+	if end > len(completions) {
+		end = len(completions)
+	}
+
+	var lines []string
+	for i := start; i < end; i++ {
+		c := completions[i]
+		// Show just the basename for cleaner display
+		display := filepath.Base(c)
+		if c[len(c)-1] == '/' {
+			display = filepath.Base(c[:len(c)-1]) + "/"
+		}
+
+		style := SidebarItemStyle
+		prefix := "  "
+		if i == s.completionIndex {
+			style = SidebarSelectedStyle
+			prefix = "> "
+		}
+		lines = append(lines, style.Render(prefix+display))
+	}
+
+	// Show scroll indicator if there are more options
+	if len(completions) > maxDisplay {
+		indicator := lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("  (" + string(rune('0'+len(completions))) + " total, scroll with up/down)")
+		if len(completions) >= 10 {
+			indicator = lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Italic(true).
+				Render("  (" + formatInt(len(completions)) + " total, scroll with up/down)")
+		}
+		lines = append(lines, indicator)
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+// formatInt converts an int to string (simple helper to avoid strconv import for small numbers)
+func formatInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
 func (s *AddRepoState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
-	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && s.SuggestedRepo != "" {
-		switch keyMsg.String() {
-		case "up", "down", "tab":
-			s.UseSuggested = !s.UseSuggested
-			if s.UseSuggested {
-				s.Input.Blur()
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		key := keyMsg.String()
+
+		// When showing completion options, handle navigation differently
+		if s.showingOptions {
+			completions := s.completer.GetCompletions()
+			switch key {
+			case "up", "k":
+				if s.completionIndex > 0 {
+					s.completionIndex--
+				}
+				return s, nil
+			case "down", "j":
+				if s.completionIndex < len(completions)-1 {
+					s.completionIndex++
+				}
+				return s, nil
+			case "tab", "enter":
+				// Select the current completion
+				if s.completionIndex < len(completions) {
+					selected := completions[s.completionIndex]
+					s.Input.SetValue(selected)
+					s.Input.CursorEnd()
+					s.lastValue = selected
+					s.showingOptions = false
+					s.completer.Reset()
+				}
+				return s, nil
+			case "esc":
+				// Hide options but don't close modal
+				s.showingOptions = false
+				s.completer.Reset()
+				return s, nil
+			default:
+				// Any other key exits option selection and updates input
+				s.showingOptions = false
+				s.completer.Reset()
+				// Fall through to normal input handling
+			}
+		}
+
+		// Handle up/down/tab to switch between suggested and custom input (when not showing options)
+		if !s.showingOptions && s.SuggestedRepo != "" && (key == "up" || key == "down" || key == "tab") {
+			// Tab when on suggested switches to input; tab when on input triggers completion (handled below)
+			if key == "tab" && !s.UseSuggested {
+				// Fall through to completion handling below
 			} else {
-				s.Input.Focus()
+				s.UseSuggested = !s.UseSuggested
+				if s.UseSuggested {
+					s.Input.Blur()
+				} else {
+					s.Input.Focus()
+				}
+				return s, nil
+			}
+		}
+
+		// Handle Tab for path completion (only when in custom input mode)
+		if key == "tab" && !s.UseSuggested && !s.showingOptions {
+			currentValue := s.Input.Value()
+			s.completer.GenerateCompletions(currentValue)
+			completions := s.completer.GetCompletions()
+
+			if len(completions) == 0 {
+				// No matches
+				return s, nil
+			} else if len(completions) == 1 {
+				// Single match - complete directly
+				s.Input.SetValue(completions[0])
+				s.Input.CursorEnd()
+				s.lastValue = completions[0]
+				s.completer.Reset()
+			} else {
+				// Multiple matches - try common prefix first
+				common := s.completer.GetCommonPrefix()
+				if common != currentValue && common != "" {
+					// Complete to common prefix
+					s.Input.SetValue(common)
+					s.Input.CursorEnd()
+					s.lastValue = common
+					// Regenerate completions for the new prefix
+					s.completer.GenerateCompletions(common)
+				}
+				// Show options if still multiple matches
+				if len(s.completer.GetCompletions()) > 1 {
+					s.showingOptions = true
+					s.completionIndex = 0
+				}
 			}
 			return s, nil
 		}
 	}
 
-	// Only update text input when it's focused
-	if !s.UseSuggested {
+	// Only update text input when it's focused and not showing options
+	if !s.UseSuggested && !s.showingOptions {
 		var cmd tea.Cmd
 		s.Input, cmd = s.Input.Update(msg)
+
+		// Reset completer if input changed (not via tab completion)
+		if s.Input.Value() != s.lastValue {
+			s.completer.Reset()
+			s.showingOptions = false
+			s.lastValue = s.Input.Value()
+		}
+
 		return s, cmd
 	}
 
@@ -100,6 +273,11 @@ func (s *AddRepoState) GetPath() string {
 	return s.Input.Value()
 }
 
+// IsShowingOptions returns true if completion options are being displayed
+func (s *AddRepoState) IsShowingOptions() bool {
+	return s.showingOptions
+}
+
 // NewAddRepoState creates a new AddRepoState with proper initialization
 func NewAddRepoState(suggestedRepo string) *AddRepoState {
 	ti := textinput.New()
@@ -108,9 +286,13 @@ func NewAddRepoState(suggestedRepo string) *AddRepoState {
 	ti.SetWidth(ModalInputWidth)
 
 	state := &AddRepoState{
-		Input:         ti,
-		SuggestedRepo: suggestedRepo,
-		UseSuggested:  suggestedRepo != "",
+		Input:           ti,
+		SuggestedRepo:   suggestedRepo,
+		UseSuggested:    suggestedRepo != "",
+		completer:       NewPathCompleter(),
+		lastValue:       "",
+		showingOptions:  false,
+		completionIndex: 0,
 	}
 
 	if suggestedRepo == "" {


### PR DESCRIPTION
## Summary
Adds filesystem path auto-completion to the Add Repository modal, allowing users to press Tab to complete directory paths when adding a new repository.

## Changes
- Add `PathCompleter` struct in `internal/ui/modals/completion.go` to handle filesystem path auto-completion
- Expand `~` to home directory automatically
- Show completion options dropdown when multiple matches exist
- Filter hidden files by default (only shown when typing `.` prefix)
- Support up/down navigation through completion options, Tab/Enter to select
- Complete to longest common prefix when multiple matches share a prefix
- Update modal help text to indicate Tab completion availability
- Add comprehensive tests for path completion logic

## Test plan
- Run `go test ./internal/ui/modals/...` to verify completion tests pass
- Build and run the app with `go build -o plural . && ./plural`
- Press `a` to open Add Repository modal
- Type a partial path (e.g., `~/Doc`) and press Tab to test completion
- Verify Tab completes to common prefix when multiple matches exist
- Verify up/down arrows navigate through completion options
- Verify Tab or Enter selects the highlighted completion
- Verify hidden directories (starting with `.`) only appear when prefix starts with `.`

Fixes #26