### PR TITLE
Simplify landing page use cases and reduce duplicate benefits

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,14 +392,14 @@
 
         <section class="use-cases fade-in">
             <h2>what you can do</h2>
-            <div class="use-case"><strong>Import GitHub issues:</strong> Press `i` to import issues from your repo. Each issue becomes a session where Claude automatically starts working on the fix.</div>
-            <div class="use-case"><strong>Branch on options:</strong> When Claude offers multiple approaches, fork the session and explore them all in parallel. Compare implementations, pick the best.</div>
-            <div class="use-case"><strong>Parallel exploration:</strong> Try two different approaches to the same problem, compare results, pick the best one.</div>
+            <div class="use-case"><strong>Import GitHub issues:</strong> Import issues from your repo and have Claude automatically start working on each fix.</div>
+            <div class="use-case"><strong>Branch on options:</strong> When Claude presents numbered options, automatically fork into parallel sessions to explore each approach.</div>
+            <div class="use-case"><strong>Parallel exploration:</strong> Manually fork a session to try different approaches to the same problem. Compare results, pick the best.</div>
             <div class="use-case"><strong>Bug + feature:</strong> Fix a production bug in one session while continuing feature work in another.</div>
             <div class="use-case"><strong>Multi-repo work:</strong> Coordinate changes across frontend and backend repos simultaneously.</div>
             <div class="use-case"><strong>Code review assist:</strong> Have Claude explain a PR in one session while you implement feedback in another.</div>
             <div class="use-case"><strong>Safe experiments:</strong> Let Claude try risky refactors in isolation. Delete the branch if it doesn't work out.</div>
-            <div class="use-case"><strong>Review before merge:</strong> Press `v` to view all changes in a session before merging or creating a PR.</div>
+            <div class="use-case"><strong>Review before merge:</strong> View all changes in a session before merging or creating a PR.</div>
         </section>
 
         <section class="benefits fade-in">
@@ -415,23 +415,16 @@
                 <div class="benefit">
                     <div class="benefit-header">
                         <span class="benefit-icon">◈</span>
-                        <h3>independent sessions</h3>
+                        <h3>independent processes</h3>
                     </div>
-                    <p>Each session has its own Claude process. Send messages to one while another is working. No waiting.</p>
+                    <p>Each session runs its own Claude CLI process. Send messages to one while another is working. No waiting.</p>
                 </div>
                 <div class="benefit">
                     <div class="benefit-header">
                         <span class="benefit-icon">⑂</span>
-                        <h3>fork on options</h3>
+                        <h3>conversation history</h3>
                     </div>
-                    <p>When Claude presents options, press Ctrl+P to fork and explore each approach in parallel. Child sessions inherit full conversation history.</p>
-                </div>
-                <div class="benefit">
-                    <div class="benefit-header">
-                        <span class="benefit-icon">⊙</span>
-                        <h3>github issue import</h3>
-                    </div>
-                    <p>Press `i` to import GitHub issues directly. Each issue becomes a session where Claude automatically receives the context and starts working.</p>
+                    <p>Forked sessions inherit full conversation history. Child sessions know everything the parent discussed.</p>
                 </div>
                 <div class="benefit">
                     <div class="benefit-header">
@@ -439,13 +432,6 @@
                         <h3>non-blocking permissions</h3>
                     </div>
                     <p>Permission prompts appear inline per-session. Approve when you're ready, or switch to a different session first.</p>
-                </div>
-                <div class="benefit">
-                    <div class="benefit-header">
-                        <span class="benefit-icon">▶</span>
-                        <h3>merge or PR</h3>
-                    </div>
-                    <p>When a session's work is ready, merge directly to main or create a GitHub PR. Claude can help resolve any merge conflicts.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
Streamlines the landing page by removing redundant content from the benefits section and making use case descriptions more concise.

## Changes
- Simplified use case descriptions to be more direct (removed unnecessary keybinding references)
- Renamed "independent sessions" to "independent processes" for clarity
- Consolidated "fork on options" into "conversation history" benefit
- Removed "github issue import" benefit (already covered in use cases section)
- Removed "merge or PR" benefit (already covered in use cases section)

## Test plan
- Open index.html in a browser and verify the use cases section reads clearly
- Verify the benefits section displays correctly with the reduced number of items
- Check that no duplicate information exists between use cases and benefits sections