### PR TITLE
Allow ctrl-e terminal shortcut when chat is focused

### DIFF
--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/git"
 	"github.com/zhubert/plural/internal/logger"
 	"github.com/zhubert/plural/internal/session"
@@ -115,7 +116,6 @@ var ShortcutRegistry = []Shortcut{
 		DisplayKey:      "ctrl-e",
 		Description:     "Open terminal in worktree",
 		Category:        CategoryGit,
-		RequiresSidebar: true,
 		RequiresSession: true,
 		Handler:         shortcutOpenTerminal,
 	},
@@ -410,7 +410,16 @@ func shortcutRenameSession(m *Model) (tea.Model, tea.Cmd) {
 }
 
 func shortcutOpenTerminal(m *Model) (tea.Model, tea.Cmd) {
-	sess := m.sidebar.SelectedSession()
+	// Use activeSession when chat is focused, otherwise use sidebar selection
+	var sess *config.Session
+	if m.chat.IsFocused() && m.activeSession != nil {
+		sess = m.activeSession
+	} else {
+		sess = m.sidebar.SelectedSession()
+	}
+	if sess == nil {
+		return m, nil
+	}
 	logger.Log("Shortcut: Opening terminal at worktree: %s", sess.WorkTree)
 	return m, openTerminalAtPath(sess.WorkTree)
 }


### PR DESCRIPTION
## Summary
Enable the ctrl-e shortcut to open a terminal in the session's worktree when the chat panel is focused, not just from the sidebar.

## Changes
- Remove `RequiresSidebar` constraint from the ctrl-e shortcut
- Update `shortcutOpenTerminal` to use the active session when chat is focused, falling back to sidebar selection otherwise
- Add nil check for session before attempting to open terminal

## Test plan
- Start plural and create/select a session
- Focus on the chat panel (tab to switch from sidebar)
- Press ctrl-e and verify terminal opens in the session's worktree
- Switch focus to sidebar and press ctrl-e to verify it still works from sidebar
- Verify no crash occurs when pressing ctrl-e with no session selected