### PR TITLE
Improve logger error handling and use append mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,7 +201,9 @@ func runMCPServer() {
 	// Extract session ID from socket path (e.g., /tmp/plural-<session-id>.sock)
 	sessionID := extractSessionID(*socketPath)
 	if sessionID != "" {
-		logger.Init(logger.MCPLogPath(sessionID))
+		if err := logger.Init(logger.MCPLogPath(sessionID)); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		}
 	}
 	defer logger.Close()
 


### PR DESCRIPTION
## Summary
- `Init()` now returns an error for callers to handle instead of silently failing
- Log files use append mode instead of truncate to preserve logs across restarts
- `ensureInit()` prints warning to stderr when log file cannot be opened

## Test plan
- [ ] Verify logger initializes correctly with `--debug` flag
- [ ] Confirm log files append rather than truncate on restart
- [ ] Test error handling when log path is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)