### PR TITLE
Fix text selection release detection on mouse button release

### DIFF
--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1395,7 +1395,9 @@ func (c *Chat) Update(msg tea.Msg) (*Chat, tea.Cmd) {
 		return c, nil
 
 	case tea.MouseReleaseMsg:
-		if c.hasSession && msg.Button == tea.MouseLeft && c.selectionActive {
+		// Note: Don't check msg.Button here - release events may not preserve the button that was released
+		// We rely on selectionActive which was set when we started selection with left click
+		if c.hasSession && c.selectionActive {
 			// Adjust coordinates for panel border
 			x := msg.X - 1
 			y := msg.Y - 1


### PR DESCRIPTION
## Summary
Fixes an issue where text selection wasn't being properly finalized on mouse release because the release event doesn't always preserve which button was released.

## Changes
- Remove the `msg.Button == tea.MouseLeft` check from mouse release handling
- Rely on `selectionActive` flag instead, which was already set when selection started with left click
- Add explanatory comment documenting why we don't check the button on release

## Test plan
- Start the application and navigate to a session with chat content
- Click and drag to select text in the chat panel
- Verify that releasing the mouse button properly finalizes the selection
- Verify that the selected text is copied to clipboard on release
- Test double-click (word selection) and triple-click (paragraph selection) still work correctly