### PR TITLE
Add plugins management feature with marketplace support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ internal/
 
 ### Data Storage
 
-- `~/.plural/config.json` - Repos, sessions, allowed tools, MCP servers, theme, branch prefix
+- `~/.plural/config.json` - Repos, sessions, allowed tools, MCP servers, plugins, theme, branch prefix
 - `~/.plural/sessions/<session-id>.json` - Conversation history (last 10,000 lines)
 
 ### Key Patterns
@@ -137,6 +137,7 @@ Available commands:
 - `/cost` - Show token usage and estimated cost for the current session (reads from Claude's JSONL session files)
 - `/help` - Show available Plural slash commands
 - `/mcp` - Open MCP servers configuration modal (same as `s` shortcut)
+- `/plugins` - Open plugin directories configuration modal
 
 Implementation in `internal/app/slash_commands.go`:
 - Commands are intercepted in `sendMessage()` before being sent to Claude
@@ -189,7 +190,31 @@ Charm's Bubble Tea v2 stack:
 - `tea.KeyMsg` → `tea.KeyPressMsg`
 - `tea.View` returns declarative view with properties
 - Viewport uses `SetWidth()`/`SetHeight()` methods
-- **Key strings**: Use `"space"` not `" "`, `"tab"` not `"\t"`, etc.
+
+**Bubble Tea v2 key strings** (use `msg.String()` on `tea.KeyPressMsg`):
+
+| Key | String | NOT |
+|-----|--------|-----|
+| Escape | `"escape"` | `"esc"` |
+| Enter | `"enter"` | `"return"` |
+| Space | `"space"` | `" "` |
+| Tab | `"tab"` | `"\t"` |
+| Backspace | `"backspace"` | |
+| Delete | `"delete"` | |
+| Up arrow | `"up"` | |
+| Down arrow | `"down"` | |
+| Left arrow | `"left"` | |
+| Right arrow | `"right"` | |
+| Page Up | `"pgup"` | |
+| Page Down | `"pgdown"` | |
+| Home | `"home"` | |
+| End | `"end"` | |
+| Ctrl+C | `"ctrl+c"` | |
+| Ctrl+S | `"ctrl+s"` | |
+| Shift+Tab | `"shift+tab"` | |
+
+Regular letter/number keys return their lowercase value (e.g., `"a"`, `"1"`, `"/"`).
+Always test key handling with actual keypresses when in doubt.
 
 ---
 

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -500,6 +500,11 @@ func shortcutMCPServers(m *Model) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func shortcutPlugins(m *Model) (tea.Model, tea.Cmd) {
+	m.showPluginsModal()
+	return m, nil
+}
+
 func shortcutTheme(m *Model) (tea.Model, tea.Cmd) {
 	m.modal.Show(ui.NewThemeState(ui.CurrentThemeName()))
 	return m, nil

--- a/internal/app/slash_commands.go
+++ b/internal/app/slash_commands.go
@@ -15,8 +15,9 @@ import (
 type SlashCommandAction int
 
 const (
-	ActionNone       SlashCommandAction = iota
-	ActionOpenMCP                       // Open MCP servers modal
+	ActionNone        SlashCommandAction = iota
+	ActionOpenMCP                        // Open MCP servers modal
+	ActionOpenPlugins                    // Open plugins modal
 )
 
 // SlashCommandResult represents the result of handling a slash command.
@@ -48,6 +49,10 @@ func getSlashCommands() []slashCommandDef {
 			name:        "mcp",
 			description: "Manage MCP servers",
 		},
+		{
+			name:        "plugins",
+			description: "Manage plugin directories",
+		},
 	}
 }
 
@@ -76,6 +81,8 @@ func (m *Model) handleSlashCommand(input string) SlashCommandResult {
 		return handleHelpCommand(m, args)
 	case "mcp":
 		return handleMCPCommand(m, args)
+	case "plugin", "plugins":
+		return handlePluginsCommand(m, args)
 	default:
 		// Unknown slash command - let Claude handle it (might be a custom command)
 		logger.Log("App: Unknown slash command /%s, passing to Claude", cmdName)
@@ -88,6 +95,14 @@ func handleMCPCommand(_ *Model, _ string) SlashCommandResult {
 	return SlashCommandResult{
 		Handled: true,
 		Action:  ActionOpenMCP,
+	}
+}
+
+// handlePluginsCommand opens the plugins configuration modal.
+func handlePluginsCommand(_ *Model, _ string) SlashCommandResult {
+	return SlashCommandResult{
+		Handled: true,
+		Action:  ActionOpenPlugins,
 	}
 }
 

--- a/internal/app/slash_commands_test.go
+++ b/internal/app/slash_commands_test.go
@@ -37,7 +37,7 @@ func TestGetSlashCommandCompletions(t *testing.T) {
 	}{
 		{"", nil},           // No prefix
 		{"hello", nil},      // Not a slash command
-		{"/", []string{"/cost", "/help", "/mcp"}},
+		{"/", []string{"/cost", "/help", "/mcp", "/plugins"}},
 		{"/c", []string{"/cost"}},
 		{"/co", []string{"/cost"}},
 		{"/cost", []string{"/cost"}},
@@ -45,6 +45,8 @@ func TestGetSlashCommandCompletions(t *testing.T) {
 		{"/help", []string{"/help"}},
 		{"/m", []string{"/mcp"}},
 		{"/mcp", []string{"/mcp"}},
+		{"/p", []string{"/plugins"}},
+		{"/plugins", []string{"/plugins"}},
 		{"/xyz", []string{}}, // No matches - returns empty slice
 	}
 
@@ -97,6 +99,18 @@ func TestHandleMCPCommand(t *testing.T) {
 
 	if result.Action != ActionOpenMCP {
 		t.Errorf("handleMCPCommand should return Action=ActionOpenMCP, got %v", result.Action)
+	}
+}
+
+func TestHandlePluginsCommand(t *testing.T) {
+	result := handlePluginsCommand(nil, "")
+
+	if !result.Handled {
+		t.Error("handlePluginsCommand should return Handled=true")
+	}
+
+	if result.Action != ActionOpenPlugins {
+		t.Errorf("handlePluginsCommand should return Action=ActionOpenPlugins, got %v", result.Action)
 	}
 }
 

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -175,6 +175,7 @@ type MCPServer struct {
 	Args    []string
 }
 
+
 // New creates a new Claude runner for a session
 func New(sessionID, workingDir string, sessionStarted bool, initialMessages []Message) *Runner {
 	logger.Log("Claude: New Runner created: sessionID=%s, workingDir=%s, started=%v, messages=%d", sessionID, workingDir, sessionStarted, len(initialMessages))
@@ -244,6 +245,7 @@ func (r *Runner) SetMCPServers(servers []MCPServer) {
 	r.mcpServers = servers
 	logger.Log("Claude: Set %d external MCP servers for session %s", len(servers), r.sessionID)
 }
+
 
 // PermissionRequestChan returns the channel for receiving permission requests.
 // Returns nil if the runner has been stopped to prevent reading from closed channel.

--- a/internal/claude/mock_runner.go
+++ b/internal/claude/mock_runner.go
@@ -236,6 +236,7 @@ func (m *MockRunner) SetMCPServers(servers []MCPServer) {
 	m.mcpServers = servers
 }
 
+
 // PermissionRequestChan implements RunnerInterface.
 func (m *MockRunner) PermissionRequestChan() <-chan mcp.PermissionRequest {
 	m.mu.RLock()

--- a/internal/claude/plugins.go
+++ b/internal/claude/plugins.go
@@ -1,0 +1,332 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/zhubert/plural/internal/logger"
+)
+
+// Marketplace represents a plugin marketplace
+type Marketplace struct {
+	Name        string
+	Source      string // "github" or "url"
+	Repo        string // e.g., "anthropics/claude-code-plugins"
+	LastUpdated time.Time
+}
+
+// Plugin represents a plugin with its status
+type Plugin struct {
+	Name        string // e.g., "frontend-design"
+	Marketplace string // e.g., "claude-code-plugins"
+	FullName    string // e.g., "frontend-design@claude-code-plugins"
+	Description string
+	Installed   bool
+	Enabled     bool
+	Version     string
+}
+
+// getClaudeDir returns the Claude config directory path
+func getClaudeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// knownMarketplacesFile is the structure of ~/.claude/plugins/known_marketplaces.json
+type knownMarketplacesFile map[string]struct {
+	Source struct {
+		Source string `json:"source"` // "github" or "url"
+		Repo   string `json:"repo"`   // e.g., "anthropics/claude-code"
+	} `json:"source"`
+	InstallLocation string `json:"installLocation"`
+	LastUpdated     string `json:"lastUpdated"`
+}
+
+// installedPluginsFile is the structure of ~/.claude/plugins/installed_plugins.json
+type installedPluginsFile struct {
+	Version int `json:"version"`
+	Plugins map[string][]struct {
+		Scope       string `json:"scope"`
+		InstallPath string `json:"installPath"`
+		Version     string `json:"version"`
+		InstalledAt string `json:"installedAt"`
+	} `json:"plugins"`
+}
+
+// settingsFile is the structure of ~/.claude/settings.json (partial)
+type settingsFile struct {
+	EnabledPlugins map[string]bool `json:"enabledPlugins"`
+}
+
+// pluginManifest is the structure of .claude-plugin/plugin.json
+type pluginManifest struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+}
+
+// ListMarketplaces returns configured marketplaces by reading the config files
+func ListMarketplaces() ([]Marketplace, error) {
+	logger.Log("Plugins: Listing marketplaces")
+
+	claudeDir := getClaudeDir()
+	if claudeDir == "" {
+		return nil, fmt.Errorf("could not find home directory")
+	}
+
+	knownPath := filepath.Join(claudeDir, "plugins", "known_marketplaces.json")
+	data, err := os.ReadFile(knownPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Log("Plugins: No marketplaces file found")
+			return []Marketplace{}, nil
+		}
+		return nil, fmt.Errorf("failed to read marketplaces: %w", err)
+	}
+
+	var known knownMarketplacesFile
+	if err := json.Unmarshal(data, &known); err != nil {
+		return nil, fmt.Errorf("failed to parse marketplaces: %w", err)
+	}
+
+	var marketplaces []Marketplace
+	for name, info := range known {
+		mp := Marketplace{
+			Name:   name,
+			Source: info.Source.Source,
+			Repo:   info.Source.Repo,
+		}
+		if info.LastUpdated != "" {
+			if t, err := time.Parse(time.RFC3339, info.LastUpdated); err == nil {
+				mp.LastUpdated = t
+			}
+		}
+		marketplaces = append(marketplaces, mp)
+	}
+
+	logger.Log("Plugins: Found %d marketplaces", len(marketplaces))
+	return marketplaces, nil
+}
+
+// ListPlugins returns all plugins with their status by reading config files and marketplace directories
+func ListPlugins() ([]Plugin, error) {
+	logger.Log("Plugins: Listing plugins")
+
+	claudeDir := getClaudeDir()
+	if claudeDir == "" {
+		return nil, fmt.Errorf("could not find home directory")
+	}
+
+	// Load installed plugins
+	installedPath := filepath.Join(claudeDir, "plugins", "installed_plugins.json")
+	installed := make(map[string]string) // fullName -> version
+	if data, err := os.ReadFile(installedPath); err == nil {
+		var installFile installedPluginsFile
+		if err := json.Unmarshal(data, &installFile); err == nil {
+			for fullName, installs := range installFile.Plugins {
+				if len(installs) > 0 {
+					installed[fullName] = installs[0].Version
+				}
+			}
+		}
+	}
+	logger.Log("Plugins: Found %d installed plugins", len(installed))
+
+	// Load enabled plugins from settings
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	enabled := make(map[string]bool)
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		var settings settingsFile
+		if err := json.Unmarshal(data, &settings); err == nil {
+			enabled = settings.EnabledPlugins
+		}
+	}
+	logger.Log("Plugins: Found %d enabled plugins", len(enabled))
+
+	// Load marketplace locations
+	knownPath := filepath.Join(claudeDir, "plugins", "known_marketplaces.json")
+	marketplaces := make(map[string]string) // name -> installLocation
+	if data, err := os.ReadFile(knownPath); err == nil {
+		var known knownMarketplacesFile
+		if err := json.Unmarshal(data, &known); err == nil {
+			for name, info := range known {
+				marketplaces[name] = info.InstallLocation
+			}
+		}
+	}
+
+	// Build plugin list from marketplace directories
+	var plugins []Plugin
+	seenPlugins := make(map[string]bool) // track which plugins we've already added
+
+	for mpName, mpPath := range marketplaces {
+		pluginsDir := filepath.Join(mpPath, "plugins")
+		entries, err := os.ReadDir(pluginsDir)
+		if err != nil {
+			logger.Log("Plugins: Could not read marketplace plugins dir %s: %v", pluginsDir, err)
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			pluginName := entry.Name()
+			fullName := pluginName + "@" + mpName
+
+			// Skip if we've already seen this plugin
+			if seenPlugins[fullName] {
+				continue
+			}
+			seenPlugins[fullName] = true
+
+			// Try to read plugin manifest
+			manifestPath := filepath.Join(pluginsDir, pluginName, ".claude-plugin", "plugin.json")
+			var description, version string
+			if data, err := os.ReadFile(manifestPath); err == nil {
+				var manifest pluginManifest
+				if err := json.Unmarshal(data, &manifest); err == nil {
+					description = manifest.Description
+					version = manifest.Version
+				}
+			}
+
+			// Determine plugin status
+			isInstalled := false
+			isEnabled := false
+			if _, ok := installed[fullName]; ok {
+				isInstalled = true
+				version = installed[fullName]
+			}
+			if enabled[fullName] {
+				isEnabled = true
+			}
+
+			plugins = append(plugins, Plugin{
+				Name:        pluginName,
+				Marketplace: mpName,
+				FullName:    fullName,
+				Description: description,
+				Installed:   isInstalled,
+				Enabled:     isEnabled,
+				Version:     version,
+			})
+		}
+	}
+
+	logger.Log("Plugins: Found %d total plugins", len(plugins))
+	return plugins, nil
+}
+
+// AddMarketplace adds a marketplace from GitHub repo or URL
+func AddMarketplace(source string) error {
+	logger.Log("Plugins: Adding marketplace: %s", source)
+
+	cmd := exec.Command("claude", "plugin", "marketplace", "add", source)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to add marketplace: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully added marketplace: %s", source)
+	return nil
+}
+
+// RemoveMarketplace removes a marketplace by name
+func RemoveMarketplace(name string) error {
+	logger.Log("Plugins: Removing marketplace: %s", name)
+
+	cmd := exec.Command("claude", "plugin", "marketplace", "remove", name)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove marketplace: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully removed marketplace: %s", name)
+	return nil
+}
+
+// UpdateMarketplace updates a marketplace (or all if name is empty)
+func UpdateMarketplace(name string) error {
+	var cmd *exec.Cmd
+	if name == "" {
+		logger.Log("Plugins: Updating all marketplaces")
+		cmd = exec.Command("claude", "plugin", "marketplace", "update")
+	} else {
+		logger.Log("Plugins: Updating marketplace: %s", name)
+		cmd = exec.Command("claude", "plugin", "marketplace", "update", name)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to update marketplace: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully updated marketplace(s)")
+	return nil
+}
+
+// InstallPlugin installs a plugin
+func InstallPlugin(fullName string) error {
+	logger.Log("Plugins: Installing plugin: %s", fullName)
+
+	cmd := exec.Command("claude", "plugin", "install", fullName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to install plugin: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully installed plugin: %s", fullName)
+	return nil
+}
+
+// UninstallPlugin removes a plugin
+func UninstallPlugin(fullName string) error {
+	logger.Log("Plugins: Uninstalling plugin: %s", fullName)
+
+	cmd := exec.Command("claude", "plugin", "uninstall", fullName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to uninstall plugin: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully uninstalled plugin: %s", fullName)
+	return nil
+}
+
+// EnablePlugin enables a plugin
+func EnablePlugin(fullName string) error {
+	logger.Log("Plugins: Enabling plugin: %s", fullName)
+
+	cmd := exec.Command("claude", "plugin", "enable", fullName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to enable plugin: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully enabled plugin: %s", fullName)
+	return nil
+}
+
+// DisablePlugin disables a plugin
+func DisablePlugin(fullName string) error {
+	logger.Log("Plugins: Disabling plugin: %s", fullName)
+
+	cmd := exec.Command("claude", "plugin", "disable", fullName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to disable plugin: %s", strings.TrimSpace(string(output)))
+	}
+
+	logger.Log("Plugins: Successfully disabled plugin: %s", fullName)
+	return nil
+}

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -13,6 +13,8 @@ import (
 type (
 	ModalState               = modals.ModalState
 	MCPServerDisplay         = modals.MCPServerDisplay
+	MarketplaceDisplay       = modals.MarketplaceDisplay
+	PluginDisplay            = modals.PluginDisplay
 	ChangelogEntry           = modals.ChangelogEntry
 	OptionItem               = modals.OptionItem
 	IssueItem                = modals.IssueItem
@@ -32,6 +34,8 @@ type (
 	ConfirmDeleteState      = modals.ConfirmDeleteState
 	MCPServersState         = modals.MCPServersState
 	AddMCPServerState       = modals.AddMCPServerState
+	PluginsState            = modals.PluginsState
+	AddMarketplaceState     = modals.AddMarketplaceState
 	WelcomeState            = modals.WelcomeState
 	ChangelogState          = modals.ChangelogState
 	ThemeState              = modals.ThemeState
@@ -55,6 +59,9 @@ var (
 	NewConfirmDeleteState      = modals.NewConfirmDeleteState
 	NewMCPServersState         = modals.NewMCPServersState
 	NewAddMCPServerState       = modals.NewAddMCPServerState
+	NewPluginsState            = modals.NewPluginsState
+	NewPluginsStateWithData    = modals.NewPluginsStateWithData
+	NewAddMarketplaceState     = modals.NewAddMarketplaceState
 	NewWelcomeState            = modals.NewWelcomeState
 	NewChangelogState          = modals.NewChangelogState
 	NewSettingsState           = modals.NewSettingsState

--- a/internal/ui/modals/plugins.go
+++ b/internal/ui/modals/plugins.go
@@ -1,0 +1,583 @@
+package modals
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// =============================================================================
+// Plugin Display Types
+// =============================================================================
+
+// MarketplaceDisplay represents a marketplace for display in the modal
+type MarketplaceDisplay struct {
+	Name        string
+	Source      string // "github" or "url"
+	Repo        string
+	LastUpdated string
+}
+
+// PluginDisplay represents a plugin for display in the modal
+type PluginDisplay struct {
+	Name        string
+	Marketplace string
+	FullName    string
+	Description string
+	Status      string // "available", "installed", "enabled"
+	Version     string
+}
+
+// =============================================================================
+// PluginsState - State for the Plugins modal with tabs
+// =============================================================================
+
+// Tab constants
+const (
+	TabMarketplaces = iota
+	TabInstalled
+	TabDiscover
+)
+
+type PluginsState struct {
+	ActiveTab      int
+	Marketplaces   []MarketplaceDisplay
+	Plugins        []PluginDisplay
+	SelectedIndex  int
+	ScrollOffset   int // For keeping selection visible
+	Loading        bool
+	Error          string
+	SearchInput    textinput.Model
+	SearchQuery    string
+	SearchFocused  bool // true = search box focused, false = list focused
+}
+
+func (*PluginsState) modalState() {}
+
+func (s *PluginsState) Title() string { return "Plugins" }
+
+func (s *PluginsState) Help() string {
+	switch s.ActiveTab {
+	case TabMarketplaces:
+		return "Tab/←/→ tabs  ↑/↓ navigate  a: add  d: delete  u: update  Esc: close"
+	case TabInstalled:
+		return "Tab/←/→ tabs  ↑/↓ navigate  e: enable/disable  u: uninstall  Esc: close"
+	case TabDiscover:
+		if s.SearchFocused {
+			return "Esc: exit search  ↑/↓ navigate  Enter: install"
+		}
+		return "Tab/←/→ tabs  /: search  ↑/↓ navigate  Enter: install  Esc: close"
+	default:
+		return "Tab/←/→ tabs  ↑/↓ navigate  Esc: close"
+	}
+}
+
+// MaxContentHeight is the maximum height for the scrollable content area
+const MaxContentHeight = 12
+
+func (s *PluginsState) Render() string {
+	title := ModalTitleStyle.Render(s.Title())
+
+	// Render tabs
+	tabs := s.renderTabs()
+
+	// Render content based on active tab
+	var content string
+	if s.Loading {
+		content = lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("Loading...")
+	} else if s.Error != "" {
+		content = StatusErrorStyle.Render(s.Error)
+	} else {
+		switch s.ActiveTab {
+		case TabMarketplaces:
+			content = s.renderMarketplaces()
+		case TabInstalled:
+			content = s.renderInstalledPlugins()
+		case TabDiscover:
+			content = s.renderDiscoverPlugins()
+		}
+	}
+
+	// Constrain content height
+	content = lipgloss.NewStyle().
+		MaxHeight(MaxContentHeight).
+		Render(content)
+
+	help := ModalHelpStyle.Render(s.Help())
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, tabs, content, help)
+}
+
+func (s *PluginsState) renderTabs() string {
+	tabNames := []string{"Marketplaces", "Installed", "Discover"}
+
+	var tabs []string
+	for i, name := range tabNames {
+		style := lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Padding(0, 1)
+		if i == s.ActiveTab {
+			style = lipgloss.NewStyle().
+				Foreground(ColorPrimary).
+				Bold(true).
+				Padding(0, 1).
+				Underline(true)
+		}
+		tabs = append(tabs, style.Render(name))
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, tabs...) + "\n"
+}
+
+func (s *PluginsState) renderMarketplaces() string {
+	if len(s.Marketplaces) == 0 {
+		return lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("No marketplaces configured.\nPress 'a' to add one.")
+	}
+
+	var content string
+	for i, m := range s.Marketplaces {
+		style := SidebarItemStyle
+		prefix := "  "
+		if i == s.SelectedIndex {
+			style = SidebarSelectedStyle
+			prefix = "> "
+		}
+
+		info := m.Name
+		if m.Source != "" {
+			info += "  " + lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Render("("+m.Source+")")
+		}
+		if m.Repo != "" {
+			info += "  " + lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Render(m.Repo)
+		}
+		content += style.Render(prefix+info) + "\n"
+	}
+
+	return content
+}
+
+func (s *PluginsState) renderInstalledPlugins() string {
+	installed := s.getInstalledPlugins()
+	if len(installed) == 0 {
+		return lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("No plugins installed.\nGo to 'Available' tab to install plugins.")
+	}
+
+	var content string
+	for i, p := range installed {
+		style := SidebarItemStyle
+		prefix := "  "
+		if i == s.SelectedIndex {
+			style = SidebarSelectedStyle
+			prefix = "> "
+		}
+
+		statusIcon := "○"
+		if p.Status == "enabled" {
+			statusIcon = "●"
+		}
+
+		info := statusIcon + " " + p.Name
+		if p.Marketplace != "" {
+			info += "  " + lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Render("@"+p.Marketplace)
+		}
+		content += style.Render(prefix+info) + "\n"
+	}
+
+	return content
+}
+
+// MaxVisibleItems is the number of items visible in the scrollable list
+const MaxVisibleItems = 5
+
+func (s *PluginsState) renderDiscoverPlugins() string {
+	// Render search input with focus indicator
+	searchLabelStyle := lipgloss.NewStyle().Foreground(ColorTextMuted)
+	if s.SearchFocused {
+		searchLabelStyle = searchLabelStyle.Foreground(ColorPrimary)
+	}
+	searchLabel := searchLabelStyle.Render("Search: ")
+	searchBox := searchLabel + s.SearchInput.View() + "\n\n"
+
+	available := s.getFilteredAvailablePlugins()
+	if len(available) == 0 {
+		msg := "No plugins found."
+		if s.SearchQuery == "" && len(s.Marketplaces) == 0 {
+			msg = "No plugins available.\nAdd a marketplace first to see plugins."
+		} else if s.SearchQuery != "" {
+			msg = "No plugins match your search."
+		}
+		return searchBox + lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render(msg)
+	}
+
+	// Apply scroll offset to show visible items
+	startIdx := s.ScrollOffset
+	endIdx := startIdx + MaxVisibleItems
+	if endIdx > len(available) {
+		endIdx = len(available)
+	}
+
+	var content string
+
+	// Show scroll indicator at top if needed
+	if startIdx > 0 {
+		content += lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Render("  ↑ more above") + "\n"
+	}
+
+	for i := startIdx; i < endIdx; i++ {
+		p := available[i]
+		style := SidebarItemStyle
+		prefix := "  "
+		if i == s.SelectedIndex {
+			style = SidebarSelectedStyle
+			prefix = "> "
+		}
+
+		info := p.Name
+		if p.Marketplace != "" {
+			info += "  " + lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Render("@"+p.Marketplace)
+		}
+		if p.Description != "" {
+			info += "\n    " + lipgloss.NewStyle().
+				Foreground(ColorTextMuted).
+				Italic(true).
+				Render(TruncateString(p.Description, 50))
+		}
+		content += style.Render(prefix+info) + "\n"
+	}
+
+	// Show scroll indicator at bottom if needed
+	if endIdx < len(available) {
+		content += lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Render("  ↓ more below") + "\n"
+	}
+
+	return searchBox + content
+}
+
+func (s *PluginsState) getInstalledPlugins() []PluginDisplay {
+	var installed []PluginDisplay
+	for _, p := range s.Plugins {
+		if p.Status == "installed" || p.Status == "enabled" {
+			installed = append(installed, p)
+		}
+	}
+	return installed
+}
+
+func (s *PluginsState) getAvailablePlugins() []PluginDisplay {
+	var available []PluginDisplay
+	for _, p := range s.Plugins {
+		if p.Status == "available" {
+			available = append(available, p)
+		}
+	}
+	return available
+}
+
+func (s *PluginsState) getFilteredAvailablePlugins() []PluginDisplay {
+	available := s.getAvailablePlugins()
+	if s.SearchQuery == "" {
+		return available
+	}
+
+	query := strings.ToLower(s.SearchQuery)
+	var filtered []PluginDisplay
+	for _, p := range available {
+		// Search in name, marketplace, and description
+		if strings.Contains(strings.ToLower(p.Name), query) ||
+			strings.Contains(strings.ToLower(p.Marketplace), query) ||
+			strings.Contains(strings.ToLower(p.Description), query) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
+func (s *PluginsState) getCurrentListLength() int {
+	switch s.ActiveTab {
+	case TabMarketplaces:
+		return len(s.Marketplaces)
+	case TabInstalled:
+		return len(s.getInstalledPlugins())
+	case TabDiscover:
+		return len(s.getFilteredAvailablePlugins())
+	default:
+		return 0
+	}
+}
+
+func (s *PluginsState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return s, nil
+	}
+
+	key := keyMsg.String()
+
+	// When search is focused, handle special keys and send rest to input
+	if s.ActiveTab == TabDiscover && s.SearchFocused {
+		switch key {
+		case "escape":
+			// Exit search mode
+			s.SearchFocused = false
+			s.SearchInput.Blur()
+			return s, nil
+		case "up", "down":
+			// Allow up/down to navigate list even when search focused
+			s.handleNavigation(key)
+			return s, nil
+		default:
+			// Send all other keys to search input
+			var cmd tea.Cmd
+			s.SearchInput, cmd = s.SearchInput.Update(msg)
+			newQuery := s.SearchInput.Value()
+			if newQuery != s.SearchQuery {
+				s.SearchQuery = newQuery
+				s.SelectedIndex = 0
+				s.ScrollOffset = 0
+			}
+			return s, cmd
+		}
+	}
+
+	// Standard navigation when search is not focused
+	switch key {
+	case "tab":
+		// Tab cycles through tabs
+		s.ActiveTab = (s.ActiveTab + 1) % 3
+		s.SelectedIndex = 0
+		s.ScrollOffset = 0
+	case "left", "h":
+		if s.ActiveTab > 0 {
+			s.ActiveTab--
+			s.SelectedIndex = 0
+			s.ScrollOffset = 0
+		}
+	case "right", "l":
+		if s.ActiveTab < TabDiscover {
+			s.ActiveTab++
+			s.SelectedIndex = 0
+			s.ScrollOffset = 0
+		}
+	case "1":
+		s.ActiveTab = TabMarketplaces
+		s.SelectedIndex = 0
+		s.ScrollOffset = 0
+	case "2":
+		s.ActiveTab = TabInstalled
+		s.SelectedIndex = 0
+		s.ScrollOffset = 0
+	case "3":
+		s.ActiveTab = TabDiscover
+		s.SelectedIndex = 0
+		s.ScrollOffset = 0
+	case "/":
+		// Enter search mode on Discover tab
+		if s.ActiveTab == TabDiscover {
+			s.SearchFocused = true
+			s.SearchInput.Focus()
+		}
+	case "up", "k", "down", "j":
+		s.handleNavigation(key)
+	}
+	return s, nil
+}
+
+// handleNavigation handles up/down navigation and scroll offset
+func (s *PluginsState) handleNavigation(key string) {
+	listLen := s.getCurrentListLength()
+	if listLen == 0 {
+		return
+	}
+
+	switch key {
+	case "up", "k":
+		if s.SelectedIndex > 0 {
+			s.SelectedIndex--
+			// Adjust scroll if selection is above visible area
+			if s.SelectedIndex < s.ScrollOffset {
+				s.ScrollOffset = s.SelectedIndex
+			}
+		}
+	case "down", "j":
+		if s.SelectedIndex < listLen-1 {
+			s.SelectedIndex++
+			// Adjust scroll if selection is below visible area
+			if s.SelectedIndex >= s.ScrollOffset+MaxVisibleItems {
+				s.ScrollOffset = s.SelectedIndex - MaxVisibleItems + 1
+			}
+		}
+	}
+}
+
+// GetSelectedMarketplace returns the selected marketplace (for delete/update)
+func (s *PluginsState) GetSelectedMarketplace() *MarketplaceDisplay {
+	if s.ActiveTab != TabMarketplaces || len(s.Marketplaces) == 0 || s.SelectedIndex >= len(s.Marketplaces) {
+		return nil
+	}
+	return &s.Marketplaces[s.SelectedIndex]
+}
+
+// GetSelectedInstalledPlugin returns the selected installed plugin (for enable/disable/uninstall)
+func (s *PluginsState) GetSelectedInstalledPlugin() *PluginDisplay {
+	if s.ActiveTab != TabInstalled {
+		return nil
+	}
+	installed := s.getInstalledPlugins()
+	if len(installed) == 0 || s.SelectedIndex >= len(installed) {
+		return nil
+	}
+	return &installed[s.SelectedIndex]
+}
+
+// GetSelectedAvailablePlugin returns the selected available plugin (for install)
+func (s *PluginsState) GetSelectedAvailablePlugin() *PluginDisplay {
+	if s.ActiveTab != TabDiscover {
+		return nil
+	}
+	available := s.getFilteredAvailablePlugins()
+	if len(available) == 0 || s.SelectedIndex >= len(available) {
+		return nil
+	}
+	return &available[s.SelectedIndex]
+}
+
+// NewPluginsState creates a new PluginsState with loading state
+func NewPluginsState() *PluginsState {
+	searchInput := textinput.New()
+	searchInput.Placeholder = "filter plugins..."
+	searchInput.CharLimit = 50
+	searchInput.SetWidth(30)
+	// Don't focus by default - Tab toggles focus
+
+	return &PluginsState{
+		ActiveTab:     TabMarketplaces,
+		Marketplaces:  []MarketplaceDisplay{},
+		Plugins:       []PluginDisplay{},
+		SelectedIndex: 0,
+		ScrollOffset:  0,
+		Loading:       true,
+		SearchInput:   searchInput,
+		SearchFocused: false,
+	}
+}
+
+// NewPluginsStateWithData creates a new PluginsState with pre-loaded data
+func NewPluginsStateWithData(marketplaces []MarketplaceDisplay, plugins []PluginDisplay) *PluginsState {
+	searchInput := textinput.New()
+	searchInput.Placeholder = "filter plugins..."
+	searchInput.CharLimit = 50
+	searchInput.SetWidth(30)
+	// Don't focus by default - Tab toggles focus
+
+	return &PluginsState{
+		ActiveTab:     TabMarketplaces,
+		Marketplaces:  marketplaces,
+		Plugins:       plugins,
+		SelectedIndex: 0,
+		ScrollOffset:  0,
+		Loading:       false,
+		SearchInput:   searchInput,
+		SearchFocused: false,
+	}
+}
+
+// SetError sets an error message
+func (s *PluginsState) SetError(err string) {
+	s.Error = err
+	s.Loading = false
+}
+
+// SetData sets the marketplaces and plugins data
+func (s *PluginsState) SetData(marketplaces []MarketplaceDisplay, plugins []PluginDisplay) {
+	s.Marketplaces = marketplaces
+	s.Plugins = plugins
+	s.Loading = false
+	s.Error = ""
+}
+
+// =============================================================================
+// AddMarketplaceState - State for the Add Marketplace modal
+// =============================================================================
+
+type AddMarketplaceState struct {
+	SourceInput textinput.Model
+}
+
+func (*AddMarketplaceState) modalState() {}
+
+func (s *AddMarketplaceState) Title() string { return "Add Marketplace" }
+
+func (s *AddMarketplaceState) Help() string {
+	return "Enter: add  Esc: cancel"
+}
+
+func (s *AddMarketplaceState) Render() string {
+	title := ModalTitleStyle.Render(s.Title())
+
+	label := lipgloss.NewStyle().
+		Foreground(ColorTextMuted).
+		MarginTop(1).
+		Render("GitHub repo or URL:")
+
+	input := s.SourceInput.View()
+
+	example := lipgloss.NewStyle().
+		Foreground(ColorTextMuted).
+		Italic(true).
+		MarginTop(1).
+		Render("e.g., anthropics/claude-code-plugins")
+
+	help := ModalHelpStyle.Render(s.Help())
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, label, input, example, help)
+}
+
+func (s *AddMarketplaceState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
+	var cmd tea.Cmd
+	s.SourceInput, cmd = s.SourceInput.Update(msg)
+	return s, cmd
+}
+
+// GetValue returns the source input value
+func (s *AddMarketplaceState) GetValue() string {
+	return s.SourceInput.Value()
+}
+
+// NewAddMarketplaceState creates a new AddMarketplaceState
+func NewAddMarketplaceState() *AddMarketplaceState {
+	sourceInput := textinput.New()
+	sourceInput.Placeholder = "owner/repo or https://..."
+	sourceInput.CharLimit = 200
+	sourceInput.SetWidth(ModalInputWidth)
+	sourceInput.Focus()
+
+	return &AddMarketplaceState{
+		SourceInput: sourceInput,
+	}
+}


### PR DESCRIPTION
## Summary
Adds a new plugins management modal to Plural that allows users to browse, install, enable/disable, and manage Claude Code plugins through plugin marketplaces.

## Changes
- Add `/plugins` slash command and modal for plugin management
- Implement three-tab interface: Marketplaces, Installed, and Discover
- Add marketplace operations: add, remove, update
- Add plugin operations: install, uninstall, enable, disable
- Add search/filter functionality in Discover tab with keyboard navigation
- Create `internal/claude/plugins.go` for Claude CLI plugin command integration
- Create `internal/ui/modals/plugins.go` for the plugins modal UI
- Update CLAUDE.md with plugins documentation and Bubble Tea v2 key string reference table

## Test plan
- Run `go build -o plural .` to verify compilation
- Run `go test ./...` to verify all tests pass
- Launch Plural and test `/plugins` command opens the modal
- Verify tab navigation with Tab, ←/→, and number keys (1/2/3)
- Test marketplace operations: `a` to add, `d` to delete, `u` to update
- Test plugin operations: `i`/Enter to install, `e` to enable/disable, `u` to uninstall
- Test search functionality with `/` in Discover tab
- Verify Esc closes modal and exits search mode appropriately

Fixes #36