### PR TITLE
Add Ctrl+D as alternative quit shortcut

### DIFF
--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -194,6 +194,13 @@ var ShortcutRegistry = []Shortcut{
 		RequiresSidebar: true,
 		Handler:         shortcutQuit,
 	},
+	{
+		Key:         "ctrl+d",
+		DisplayKey:  "ctrl-d",
+		Description: "Quit application",
+		Category:    CategoryGeneral,
+		Handler:     shortcutQuit,
+	},
 }
 
 // helpShortcut is defined separately to avoid initialization cycle.


### PR DESCRIPTION
## Summary
Adds Ctrl+D as an additional keyboard shortcut to quit the application, complementing the existing quit shortcut.

## Changes
- Add Ctrl+D to the shortcut registry with the same quit handler
- Shortcut appears in help modal automatically via the registry system

## Test plan
- Run `./plural` and press Ctrl+D to verify the application quits
- Check help modal (?) to confirm Ctrl+D appears as a quit shortcut