### PR TITLE
Fix double-click word selection not copying to clipboard

### DIFF
--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1401,19 +1401,27 @@ func (c *Chat) Update(msg tea.Msg) (*Chat, tea.Cmd) {
 			// Adjust coordinates for panel border
 			x := msg.X - 1
 			y := msg.Y - 1
-			c.EndSelection(x, y)
-			clickCount := c.clickCount
 
-			// Schedule delayed copy to allow for multi-click detection
-			tick := tea.Tick(doubleClickThreshold, func(time.Time) tea.Msg {
-				return SelectionCopyMsg{
-					clickCount:   clickCount,
-					endSelection: true,
-					x:            x,
-					y:            y,
-				}
-			})
-			return c, tick
+			// For drag selections, update the end position
+			if c.selectionActive {
+				c.EndSelection(x, y)
+			}
+
+			// Copy if we have a selection (either from drag or double/triple click)
+			if c.HasTextSelection() {
+				clickCount := c.clickCount
+
+				// Schedule delayed copy to allow for multi-click detection
+				tick := tea.Tick(doubleClickThreshold, func(time.Time) tea.Msg {
+					return SelectionCopyMsg{
+						clickCount:   clickCount,
+						endSelection: true,
+						x:            x,
+						y:            y,
+					}
+				})
+				return c, tick
+			}
 		}
 		return c, nil
 


### PR DESCRIPTION
## Summary
Fixes a bug where double-click word selection wasn't copying text to the clipboard.

## Changes
- Changed mouse release handler to check `HasTextSelection()` instead of only `selectionActive`
- Double/triple click selections set `HasTextSelection()` but not `selectionActive` (which is only set during drag operations)
- Now properly triggers the delayed copy for all selection types

## Test plan
- Double-click on a word in the chat panel - should copy the word to clipboard
- Triple-click on a line - should copy the paragraph to clipboard
- Click and drag to select text - should still copy on release
- Verify all three selection methods result in text being copied to system clipboard