### PR TITLE
Fix Escape key to exit view changes mode from sidebar focus

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -265,11 +265,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleModalKey(msg)
 		}
 
-		// Handle Escape to exit search mode or interrupt streaming
+		// Handle Escape to exit search mode, view changes mode, or interrupt streaming
 		if msg.String() == "esc" {
 			// First check if sidebar is in search mode
 			if m.sidebar.IsSearchMode() {
 				m.sidebar.ExitSearchMode()
+				return m, nil
+			}
+			// Check if view changes mode is active (regardless of focus)
+			if m.chat.IsInViewChangesMode() {
+				m.chat.ExitViewChangesMode()
 				return m, nil
 			}
 			// Then check for streaming interruption

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -775,6 +775,43 @@ func TestViewChanges_NavigateFiles(t *testing.T) {
 	}
 }
 
+func TestViewChanges_EscapeFromSidebarFocus(t *testing.T) {
+	cfg := testConfigWithSessions()
+	m, _ := testModelWithMocks(cfg, 120, 40)
+	m.sidebar.SetSessions(cfg.Sessions)
+
+	// Select a session first (this switches focus to chat)
+	m = sendKey(m, "enter")
+	if m.activeSession == nil {
+		t.Fatal("Expected active session")
+	}
+
+	// Enter view changes mode (simulating what shortcutViewChanges does)
+	m.chat.EnterViewChangesMode(testFileDiffs())
+
+	if !m.chat.IsInViewChangesMode() {
+		t.Fatal("Expected to be in view changes mode")
+	}
+
+	// Switch focus back to sidebar (Tab)
+	m = sendKey(m, "tab")
+	if m.focus != FocusSidebar {
+		t.Fatalf("Expected sidebar focus after tab, got %v", m.focus)
+	}
+
+	// Verify still in view changes mode
+	if !m.chat.IsInViewChangesMode() {
+		t.Fatal("Should still be in view changes mode after switching to sidebar")
+	}
+
+	// Press Escape from sidebar - should close view changes mode
+	m = sendKey(m, "esc")
+
+	if m.chat.IsInViewChangesMode() {
+		t.Error("Expected to exit view changes mode after Escape from sidebar")
+	}
+}
+
 // =============================================================================
 // Fork Modal Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
Fixes an issue where pressing Escape while focused on the sidebar would not exit view changes mode. Previously, you could only exit view changes mode with Escape when the chat panel had focus.

## Changes
- Modified Escape key handling in `app.go` to check for view changes mode regardless of current focus
- Moved the view changes mode check before the streaming interruption check to ensure proper handling
- Added integration test `TestViewChanges_EscapeFromSidebarFocus` to verify the fix

## Test plan
- Run `go test ./...` to execute the new integration test
- Manual testing:
  1. Start a session and make some changes
  2. Press `c` to enter view changes mode
  3. Press `Tab` to switch focus to the sidebar
  4. Press `Escape` - should now exit view changes mode (previously did nothing)