### PR TITLE
Update docs with user preferences, slash commands, and install options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,19 @@ Merge types enum: `MergeTypeMerge` (to main), `MergeTypePR` (create PR), `MergeT
 
 Issue number stored in session. When PR created from issue session, "Fixes #N" auto-added to PR body. Branch naming: `issue-{number}`.
 
+### User Preferences
+
+**Themes** (`t` key): 8 built-in themes defined in `internal/ui/theme.go`:
+- Dark Purple (default), Nord, Dracula, Gruvbox Dark, Tokyo Night, Catppuccin Mocha, Science Fiction, Light
+
+**Settings** (`,` key): Opens modal for:
+- Branch prefix (e.g., `yourname/` creates branches like `yourname/plural-abc123`)
+- Desktop notifications toggle
+
+**Session rename** (`r` key): Renames session and its git branch.
+
+**Message search** (`Ctrl+/`): Search within conversation history when chat is focused.
+
 ### Slash Commands
 
 Plural implements its own slash commands because Claude CLI built-in commands (like `/cost`, `/help`, `/mcp`) are designed for interactive REPL mode and don't work in stream-json mode.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Press `t` to choose from:
 - Gruvbox Dark
 - Tokyo Night
 - Catppuccin Mocha
+- Science Fiction
 - Light
 
 ### Settings
@@ -221,6 +222,17 @@ Extend Claude's capabilities with MCP servers:
 
 Example: Add a GitHub MCP server globally, or a database server for a specific project.
 
+### Slash Commands
+
+Plural provides its own slash commands (Claude CLI's built-in commands don't work in stream-json mode):
+
+- `/cost` - Show token usage and estimated cost for the current session
+- `/help` - Show available Plural slash commands
+- `/mcp` - Open MCP servers configuration modal
+- `/plugins` - Open plugin directories configuration modal
+
+Other slash commands are passed through to Claude CLI.
+
 ---
 
 ## Reference
@@ -238,6 +250,7 @@ plural                  # Start the application
 plural --check-prereqs  # Verify required tools
 plural --clear          # Remove all sessions
 plural --prune          # Clean up orphaned worktrees
+plural --debug          # Enable debug logging
 ```
 
 ### Troubleshooting

--- a/index.html
+++ b/index.html
@@ -368,6 +368,7 @@
 
         <div class="hero-pitch fade-in">
             <p>Run multiple Claude sessions on the same codebase—each in its own git branch. When Claude offers different approaches, fork the session and try them all in parallel. Switch freely. Merge the winner.</p>
+            <p style="margin-top: 0.75rem; font-size: 0.8rem;">Requires <a href="https://docs.anthropic.com/en/docs/claude-code" style="color: var(--secondary); text-decoration: none;">Claude Code CLI</a> installed and authenticated.</p>
         </div>
 
         <div class="demo-container fade-in">
@@ -379,6 +380,14 @@
             <div class="command-block">
                 <button class="copy-btn" onclick="copyCommand(this, 'brew tap zhubert/tap && brew install plural')">copy</button>
                 <code><span class="prompt">$</span> brew tap zhubert/tap && brew install plural</code>
+            </div>
+        </section>
+
+        <section class="install fade-in">
+            <h2>install via nix</h2>
+            <div class="command-block">
+                <button class="copy-btn" onclick="copyCommand(this, 'nix profile install github:zhubert/plural')">copy</button>
+                <code><span class="prompt">$</span> nix profile install github:zhubert/plural</code>
             </div>
         </section>
 
@@ -442,7 +451,7 @@
         </nav>
 
         <footer>
-            <p>built with <a href="https://github.com/charmbracelet/bubbletea">bubble tea</a> · mit license</p>
+            <p>built with <a href="https://charm.land/bubbletea">bubble tea</a> · mit license</p>
         </footer>
     </div>
 


### PR DESCRIPTION
## Summary
Documentation improvements across CLAUDE.md, README.md, and the website to cover user preferences, slash commands, and additional installation methods.

## Changes
- Add User Preferences section to CLAUDE.md documenting themes, settings, session rename, and message search
- Add Science Fiction theme to README.md theme list
- Document slash commands (`/cost`, `/help`, `/mcp`, `/plugins`) in README.md
- Add `--debug` flag to CLI reference in README.md
- Add Nix installation option to website
- Add Claude Code CLI prerequisite note to website hero section
- Update Bubble Tea link to new charm.land URL

## Test plan
- Verify documentation renders correctly on GitHub
- Test website locally to confirm new install section displays properly
- Confirm all documented keyboard shortcuts match actual functionality