### PR TITLE
Add support for letter-based options (A, B, C) in explore modal

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1266,6 +1266,7 @@ func (m *Model) showExploreOptionsModal() (tea.Model, tea.Cmd) {
 	for i, opt := range options {
 		items[i] = ui.OptionItem{
 			Number:     opt.Number,
+			Letter:     opt.Letter,
 			Text:       opt.Text,
 			Selected:   false,
 			GroupIndex: opt.GroupIndex,

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 )
 
-// DetectedOption represents a numbered option found in Claude's response
+// DetectedOption represents a numbered or lettered option found in Claude's response
 type DetectedOption struct {
-	Number     int    // The option number (1, 2, 3, etc.)
+	Number     int    // The option number (1, 2, 3, etc.) or letter index (A=1, B=2, etc.)
+	Letter     string // The option letter if letter-based (A, B, C, etc.), empty if numeric
 	Text       string // The option text
 	GroupIndex int    // Which group this option belongs to (0-indexed)
 }
@@ -19,9 +20,9 @@ var optionsTagPattern = regexp.MustCompile(`(?s)<options>\s*(.*?)\s*</options>`)
 // optgroupTagPattern matches <optgroup>...</optgroup> blocks within options.
 var optgroupTagPattern = regexp.MustCompile(`(?s)<optgroup>\s*(.*?)\s*</optgroup>`)
 
-// optionPatterns are regexes that match numbered lists in Claude responses.
+// numericOptionPatterns are regexes that match numbered lists in Claude responses.
 // These are used as fallback when <options> tags are not present.
-var optionPatterns = []*regexp.Regexp{
+var numericOptionPatterns = []*regexp.Regexp{
 	// Standard numbered list: "1. Option text" or "1) Option text"
 	regexp.MustCompile(`(?m)^(\d+)[.)]\s+(.+)$`),
 	// Markdown bold option: "**Option 1:** text" or "**1.** text"
@@ -30,9 +31,19 @@ var optionPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?m)^#{2,3}\s+Option\s+(\d+):?\s*(.+)$`),
 }
 
-// DetectOptions scans a message for numbered options.
+// letterOptionPatterns are regexes that match letter-based lists (A, B, C, etc.)
+var letterOptionPatterns = []*regexp.Regexp{
+	// Markdown heading option: "## Option A: text" or "### Option A: text"
+	regexp.MustCompile(`(?m)^#{2,3}\s+Option\s+([A-Z]):?\s*(.+)$`),
+	// Markdown bold option: "**Option A:** text" or "**A.** text"
+	regexp.MustCompile(`(?m)^\*\*(?:Option\s+)?([A-Z])[.:]?\*\*:?\s*(.+)$`),
+	// Standard letter list: "A. Option text" or "A) Option text"
+	regexp.MustCompile(`(?m)^([A-Z])[.)]\s+(.+)$`),
+}
+
+// DetectOptions scans a message for numbered or lettered options.
 // It first looks for <options> tags (most reliable), then falls back to
-// pattern matching on numbered lists.
+// pattern matching on numbered lists, then letter-based lists.
 // Returns nil if no valid option list is found.
 func DetectOptions(message string) []DetectedOption {
 	// First, try to find options within <options> tags (most reliable)
@@ -40,8 +51,19 @@ func DetectOptions(message string) []DetectedOption {
 		return options
 	}
 
-	// Fallback: try pattern matching
-	for _, pattern := range optionPatterns {
+	// Try letter-based patterns first (they're more specific, like "Option A:")
+	for _, pattern := range letterOptionPatterns {
+		matches := pattern.FindAllStringSubmatch(message, -1)
+		if len(matches) >= 2 {
+			options := extractSequentialLetterOptions(matches)
+			if len(options) >= 2 {
+				return options
+			}
+		}
+	}
+
+	// Fallback: try numeric pattern matching
+	for _, pattern := range numericOptionPatterns {
 		matches := pattern.FindAllStringSubmatch(message, -1)
 		if len(matches) >= 2 {
 			options := extractSequentialOptions(matches)
@@ -99,7 +121,7 @@ func detectOptionsFromTags(message string) []DetectedOption {
 	}
 
 	// No optgroups, parse the content directly
-	for _, pattern := range optionPatterns {
+	for _, pattern := range numericOptionPatterns {
 		lineMatches := pattern.FindAllStringSubmatch(content, -1)
 		if len(lineMatches) >= 2 {
 			options := extractSequentialOptions(lineMatches)
@@ -114,7 +136,7 @@ func detectOptionsFromTags(message string) []DetectedOption {
 
 // parseOptionsFromContent parses numbered options from content, assigning the given group index.
 func parseOptionsFromContent(content string, groupIndex int) []DetectedOption {
-	for _, pattern := range optionPatterns {
+	for _, pattern := range numericOptionPatterns {
 		lineMatches := pattern.FindAllStringSubmatch(content, -1)
 		if len(lineMatches) >= 2 {
 			var options []DetectedOption
@@ -192,6 +214,79 @@ func extractSequentialOptions(matches [][]string) []DetectedOption {
 				Text:   text,
 			}}
 		default:
+			// Break in sequence, save current group if valid
+			if len(currentGroup) >= 2 {
+				allGroups = append(allGroups, currentGroup)
+			}
+			currentGroup = nil
+		}
+	}
+
+	// Don't forget the last group
+	if len(currentGroup) >= 2 {
+		allGroups = append(allGroups, currentGroup)
+	}
+
+	// Flatten all groups with GroupIndex set
+	var result []DetectedOption
+	for groupIdx, group := range allGroups {
+		for _, opt := range group {
+			opt.GroupIndex = groupIdx
+			result = append(result, opt)
+		}
+	}
+
+	return result
+}
+
+// extractSequentialLetterOptions finds all sequential runs of lettered options
+// starting from A. Returns all groups flattened with GroupIndex set.
+func extractSequentialLetterOptions(matches [][]string) []DetectedOption {
+	if len(matches) == 0 {
+		return nil
+	}
+
+	// Find all option groups (sequences starting from A)
+	var allGroups [][]DetectedOption
+	var currentGroup []DetectedOption
+
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		letter := strings.ToUpper(match[1])
+		if len(letter) != 1 || letter[0] < 'A' || letter[0] > 'Z' {
+			continue
+		}
+		letterIndex := int(letter[0] - 'A' + 1) // A=1, B=2, etc.
+
+		text := strings.TrimSpace(match[2])
+		if text == "" {
+			continue
+		}
+
+		// Check if this continues the sequence or starts a new one
+		expectedIndex := len(currentGroup) + 1
+		expectedLetter := string('A' + byte(expectedIndex-1))
+
+		if letter == expectedLetter {
+			currentGroup = append(currentGroup, DetectedOption{
+				Number: letterIndex,
+				Letter: letter,
+				Text:   text,
+			})
+		} else if letter == "A" {
+			// Start a new group
+			if len(currentGroup) >= 2 {
+				allGroups = append(allGroups, currentGroup)
+			}
+			currentGroup = []DetectedOption{{
+				Number: 1,
+				Letter: "A",
+				Text:   text,
+			}}
+		} else {
 			// Break in sequence, save current group if valid
 			if len(currentGroup) >= 2 {
 				allGroups = append(allGroups, currentGroup)

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -126,13 +126,20 @@ func GetDisplayContent(blocks []ContentBlock) string {
 
 // OptionsSystemPrompt is appended to Claude's system prompt to request structured option formatting.
 // This allows Plural to reliably detect when Claude presents numbered choices to the user.
-const OptionsSystemPrompt = `When presenting the user with numbered choices or options to choose from, wrap the options in <options> tags. For example:
+const OptionsSystemPrompt = `When presenting the user with numbered or lettered choices or options to choose from, wrap the options in <options> tags. For example:
 <options>
 1. First option
 2. Second option
 3. Third option
 </options>
 The opening and closing tags should be on their own lines, with the numbered options between them.
+
+This also applies to letter-based options (A, B, C, etc.):
+<options>
+A. First approach
+B. Second approach
+C. Third approach
+</options>
 
 If you have multiple groups of options (e.g., high priority and low priority items), use <optgroup> tags within the <options> block:
 <options>

--- a/internal/ui/modals/explore.go
+++ b/internal/ui/modals/explore.go
@@ -74,7 +74,14 @@ func (s *ExploreOptionsState) Render() string {
 			text = text[:47] + "..."
 		}
 
-		optionLine := fmt.Sprintf("%s %d. %s", checkbox, opt.Number, text)
+		// Use letter label if present, otherwise use number
+		var label string
+		if opt.Letter != "" {
+			label = opt.Letter
+		} else {
+			label = fmt.Sprintf("%d", opt.Number)
+		}
+		optionLine := fmt.Sprintf("%s %s. %s", checkbox, label, text)
 		optionList += style.Render(prefix+optionLine) + "\n"
 	}
 

--- a/internal/ui/modals/state.go
+++ b/internal/ui/modals/state.go
@@ -37,6 +37,7 @@ type ChangelogEntry struct {
 // OptionItem represents a detected option for display
 type OptionItem struct {
 	Number     int
+	Letter     string // Letter label if option is letter-based (A, B, C), empty if numeric
 	Text       string
 	Selected   bool
 	GroupIndex int // Which group this option belongs to (for visual separation)


### PR DESCRIPTION
## Summary
Extends the explore options detection to recognize letter-based option lists (A, B, C, etc.) in addition to numbered lists (1, 2, 3). This allows Plural to properly parse and display options when Claude presents choices using letter labels.

## Changes
- Add `Letter` field to `DetectedOption` struct to store letter labels (A, B, C, etc.)
- Add `letterOptionPatterns` regex patterns to match letter-based formats:
  - Markdown headings: `## Option A: text`
  - Markdown bold: `**Option A:** text`
  - Standard lists: `A. text` or `A) text`
- Implement `extractSequentialLetterOptions()` to find sequential runs of lettered options starting from A
- Update detection order to try letter patterns before numeric fallback (letter patterns are more specific)
- Update `OptionsSystemPrompt` to instruct Claude about letter-based option formatting
- Update explore modal UI to display letter or number labels appropriately
- Add comprehensive tests for letter-based option detection

## Test plan
- Run `go test ./internal/app/...` to verify all option detection tests pass
- Test with Claude responses containing letter-based options (e.g., "## Option A:", "A. Choice")
- Verify the explore modal (`Ctrl+P`) correctly displays options with letter labels
- Confirm numeric options still work as before
- Test edge cases: non-sequential letters, single letter option (should be ignored)