### PR TITLE
Add visual flash feedback when copying selected text

### DIFF
--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -91,6 +91,9 @@ type Chat struct {
 	lastClickX    int
 	lastClickY    int
 	clickCount    int
+
+	// Selection flash animation (brief highlight after copy, then clear)
+	selectionFlashFrame int // -1 = inactive, 0 = flash visible, 1+ = done
 }
 
 // NewChat creates a new chat panel
@@ -118,6 +121,7 @@ func NewChat() *Chat {
 		messages:             []claude.Message{},
 		lastToolUsePos:       -1,
 		completionFlashFrame: -1,
+		selectionFlashFrame:  -1,
 	}
 	c.updateContent()
 	return c
@@ -884,6 +888,17 @@ func (c *Chat) Update(msg tea.Msg) (*Chat, tea.Cmd) {
 		cmd := c.handleCompletionFlashTick()
 		if cmd != nil {
 			cmds = append(cmds, cmd)
+		}
+		return c, tea.Batch(cmds...)
+
+	case SelectionFlashTickMsg:
+		if c.selectionFlashFrame >= 0 {
+			c.selectionFlashFrame++
+			if c.selectionFlashFrame >= 1 {
+				// Flash complete - clear the selection
+				c.SelectionClear()
+				c.selectionFlashFrame = -1
+			}
 		}
 		return c, tea.Batch(cmds...)
 	}

--- a/internal/ui/chat_animation.go
+++ b/internal/ui/chat_animation.go
@@ -14,6 +14,9 @@ type StopwatchTickMsg time.Time
 // CompletionFlashTickMsg is sent to animate the completion checkmark flash
 type CompletionFlashTickMsg time.Time
 
+// SelectionFlashTickMsg is sent to animate the selection copy flash
+type SelectionFlashTickMsg time.Time
+
 // thinkingVerbs are playful status messages that cycle while waiting for Claude
 var thinkingVerbs = []string{
 	"Thinking",
@@ -65,6 +68,13 @@ func CompletionFlashTick() tea.Cmd {
 	})
 }
 
+// SelectionFlashTick returns a command that sends a selection flash tick
+func SelectionFlashTick() tea.Cmd {
+	return tea.Tick(150*time.Millisecond, func(t time.Time) tea.Msg {
+		return SelectionFlashTickMsg(t)
+	})
+}
+
 // StartCompletionFlash starts the completion checkmark flash animation
 func (c *Chat) StartCompletionFlash() tea.Cmd {
 	c.completionFlashFrame = 0
@@ -75,6 +85,11 @@ func (c *Chat) StartCompletionFlash() tea.Cmd {
 // IsCompletionFlashing returns whether the completion flash animation is active
 func (c *Chat) IsCompletionFlashing() bool {
 	return c.completionFlashFrame >= 0
+}
+
+// IsSelectionFlashing returns whether the selection flash animation is active
+func (c *Chat) IsSelectionFlashing() bool {
+	return c.selectionFlashFrame >= 0
 }
 
 // renderSpinner renders the shimmering spinner with the thinking verb.

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -264,4 +264,9 @@ var (
 	TextSelectionStyle = lipgloss.NewStyle().
 				Background(lipgloss.Color("#4C1D95")). // Purple background
 				Foreground(lipgloss.Color("#F9FAFB"))  // Light text
+
+	// TextSelectionFlashStyle is used briefly when text is copied to indicate success
+	TextSelectionFlashStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color("#10B981")). // Green background (success)
+				Foreground(lipgloss.Color("#FFFFFF"))  // White text
 )


### PR DESCRIPTION
## Summary
Adds a brief green flash animation when text is copied from the chat panel, providing clear visual feedback that the copy operation succeeded before automatically clearing the selection.

## Changes
- Add `selectionFlashFrame` state to track flash animation progress
- Create `SelectionFlashTickMsg` and `SelectionFlashTick()` for animation timing
- Add `IsSelectionFlashing()` helper method
- Modify `CopySelectedText()` to start flash animation after copy
- Add `TextSelectionFlashStyle` with green background to indicate success
- Update `selectionView()` to use flash style during animation frame
- Selection automatically clears after flash completes (150ms)
- Add comprehensive tests for flash animation behavior

## Test plan
- Run `go test ./internal/ui/...` to verify all new tests pass
- Build and run the app with `go build -o plural . && ./plural`
- Select text in the chat panel by clicking and dragging
- Release mouse button to copy - observe brief green flash before selection clears
- Verify text is correctly copied to clipboard