### PR TITLE
Add fork-session support to inherit parent conversation history

### DIFF
--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -189,6 +189,13 @@ func (sm *SessionManager) getOrCreateRunner(sess *config.Session) claude.RunnerI
 	runner := sm.runnerFactory(sess.ID, sess.WorkTree, sess.Started, initialMsgs)
 	sm.runners[sess.ID] = runner
 
+	// If this is a forked session that hasn't started yet, set up to fork from parent
+	// to inherit the parent's conversation history in Claude
+	if !sess.Started && sess.ParentID != "" {
+		runner.SetForkFromSession(sess.ParentID)
+		logger.Log("SessionManager: Session %s will fork from parent %s", sess.ID, sess.ParentID)
+	}
+
 	// Load allowed tools from config (global + per-repo)
 	allowedTools := sm.config.GetAllowedToolsForRepo(sess.RepoPath)
 	if len(allowedTools) > 0 {

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -138,6 +138,26 @@ func TestRunner_SetMCPServers(t *testing.T) {
 	}
 }
 
+func TestRunner_SetForkFromSession(t *testing.T) {
+	runner := New("child-session", "/tmp", false, nil)
+
+	// Initially no fork parent
+	runner.mu.RLock()
+	if runner.forkFromSessionID != "" {
+		t.Errorf("Expected empty forkFromSessionID initially, got %q", runner.forkFromSessionID)
+	}
+	runner.mu.RUnlock()
+
+	// Set fork parent
+	runner.SetForkFromSession("parent-session")
+
+	runner.mu.RLock()
+	if runner.forkFromSessionID != "parent-session" {
+		t.Errorf("Expected forkFromSessionID 'parent-session', got %q", runner.forkFromSessionID)
+	}
+	runner.mu.RUnlock()
+}
+
 func TestRunner_IsStreaming(t *testing.T) {
 	runner := New("session-1", "/tmp", false, nil)
 

--- a/internal/claude/mock_runner.go
+++ b/internal/claude/mock_runner.go
@@ -236,6 +236,11 @@ func (m *MockRunner) SetMCPServers(servers []MCPServer) {
 	m.mcpServers = servers
 }
 
+// SetForkFromSession implements RunnerInterface.
+// In mock, this is a no-op since we don't spawn real processes.
+func (m *MockRunner) SetForkFromSession(parentSessionID string) {
+	// No-op for mock
+}
 
 // PermissionRequestChan implements RunnerInterface.
 func (m *MockRunner) PermissionRequestChan() <-chan mcp.PermissionRequest {

--- a/internal/claude/runner_interface.go
+++ b/internal/claude/runner_interface.go
@@ -25,6 +25,7 @@ type RunnerInterface interface {
 	SetAllowedTools(tools []string)
 	AddAllowedTool(tool string)
 	SetMCPServers(servers []MCPServer)
+	SetForkFromSession(parentSessionID string)
 
 	// Permission/Question channels
 	PermissionRequestChan() <-chan mcp.PermissionRequest


### PR DESCRIPTION
## Summary
When forking a session, the child session now inherits the parent's conversation history by using Claude CLI's `--resume <parentID> --fork-session` flags. This allows forked sessions to continue from the parent's context rather than starting fresh.

## Changes
- Add `SetForkFromSession(parentSessionID string)` method to `RunnerInterface` and implementations
- Update `Runner.startPersistentProcess()` to use `--resume <parentID> --fork-session` flags when a fork parent is set
- Update `SessionManager.getOrCreateRunner()` to configure fork parent for new child sessions that haven't started yet
- Add comprehensive tests for fork session behavior in both session manager and claude runner

## Test plan
- Run `go test ./...` to verify all tests pass
- Create a session and send a few messages to establish conversation history
- Fork the session using `f` key with "Copy conversation history" option
- Verify the forked session can reference context from the parent conversation
- Verify already-started sessions resume normally without forking
- Verify non-forked sessions start fresh without the fork flags