### PR TITLE
Add thread-safety to session manager and improve UI handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -512,6 +512,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, ui.FlashTick())
 		}
 		return m, tea.Batch(cmds...)
+	case ui.ClipboardErrorMsg:
+		// Show error message when clipboard write fails
+		m.footer.SetFlash("Failed to copy to clipboard", ui.FlashError)
+		cmds = append(cmds, ui.FlashTick())
+		return m, tea.Batch(cmds...)
 	}
 
 	// Route scroll keys and mouse wheel to chat panel even when sidebar is focused

--- a/internal/app/session_state.go
+++ b/internal/app/session_state.go
@@ -61,18 +61,12 @@ func NewSessionStateManager() *SessionStateManager {
 	}
 }
 
-// Get returns the state for a session, creating it if it doesn't exist.
-func (m *SessionStateManager) Get(sessionID string) *SessionState {
+// GetOrCreate returns the state for a session, creating it if it doesn't exist.
+// Use GetIfExists when you don't want to create state for sessions that haven't been accessed.
+func (m *SessionStateManager) GetOrCreate(sessionID string) *SessionState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	if state, exists := m.states[sessionID]; exists {
-		return state
-	}
-
-	state := &SessionState{}
-	m.states[sessionID] = state
-	return state
+	return m.getOrCreate(sessionID)
 }
 
 // GetIfExists returns the state for a session if it exists, nil otherwise.

--- a/internal/app/session_state_test.go
+++ b/internal/app/session_state_test.go
@@ -13,13 +13,13 @@ import (
 func TestSessionStateManager_GetCreatesState(t *testing.T) {
 	m := NewSessionStateManager()
 
-	state := m.Get("session-1")
+	state := m.GetOrCreate("session-1")
 	if state == nil {
 		t.Fatal("expected non-nil state")
 	}
 
 	// Getting the same session should return the same state
-	state2 := m.Get("session-1")
+	state2 := m.GetOrCreate("session-1")
 	if state != state2 {
 		t.Error("expected same state object on second Get")
 	}
@@ -35,7 +35,7 @@ func TestSessionStateManager_GetIfExistsDoesNotCreate(t *testing.T) {
 	}
 
 	// Create the session
-	m.Get("session-1")
+	m.GetOrCreate("session-1")
 
 	// Now it should exist
 	state = m.GetIfExists("session-1")
@@ -48,7 +48,7 @@ func TestSessionStateManager_Delete(t *testing.T) {
 	m := NewSessionStateManager()
 
 	// Create and then delete
-	m.Get("session-1")
+	m.GetOrCreate("session-1")
 	m.Delete("session-1")
 
 	// Should be gone
@@ -284,7 +284,7 @@ func TestSessionStateManager_ConcurrentAccess(t *testing.T) {
 			for j := 0; j < numOperations; j++ {
 				switch j % 6 {
 				case 0:
-					m.Get(sessionID)
+					m.GetOrCreate(sessionID)
 				case 1:
 					m.SetPendingPermission(sessionID, &mcp.PermissionRequest{ID: "perm"})
 					m.ClearPendingPermission(sessionID)

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -173,16 +173,22 @@ func applyTextareaStyles(ti *textarea.Model) {
 
 // SetSize sets the chat panel dimensions
 func (c *Chat) SetSize(width, height int) {
+	// Check if viewport width changed - if so, invalidate message cache
+	// since messages are wrapped based on viewport width
+	ctx := GetViewContext()
+	newInnerWidth := ctx.InnerWidth(width)
+	if c.viewport.Width() != newInnerWidth && c.viewport.Width() > 0 {
+		c.messageCache = nil // Clear cache to force re-render at new width
+	}
+
 	c.width = width
 	c.height = height
-
-	ctx := GetViewContext()
 
 	// Chat panel height (excluding input area which is separate)
 	chatPanelHeight := height - InputTotalHeight
 
 	// Calculate inner dimensions for the chat panel (accounting for borders)
-	innerWidth := ctx.InnerWidth(width)
+	innerWidth := newInnerWidth
 	viewportHeight := ctx.InnerHeight(chatPanelHeight)
 
 	if viewportHeight < 1 {

--- a/internal/ui/constants.go
+++ b/internal/ui/constants.go
@@ -15,6 +15,12 @@ const (
 	// SidebarWidthRatio is the denominator for sidebar width (1/3 of total width)
 	SidebarWidthRatio = 3
 
+	// MinTerminalWidth is the minimum supported terminal width
+	MinTerminalWidth = 40
+
+	// MinTerminalHeight is the minimum supported terminal height
+	MinTerminalHeight = 10
+
 	// TextareaHeight is the number of lines for the chat input textarea
 	TextareaHeight = 3
 

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -44,8 +44,21 @@ func (v *ViewContext) Log(format string, args ...interface{}) {
 	logger.Log(format, args...)
 }
 
-// UpdateTerminalSize recalculates all dimensions when terminal size changes
+// UpdateTerminalSize recalculates all dimensions when terminal size changes.
+// This method is thread-safe and should be called from the main event loop
+// when the terminal is resized.
 func (v *ViewContext) UpdateTerminalSize(width, height int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	// Validate dimensions to prevent negative layout values
+	if width < MinTerminalWidth {
+		width = MinTerminalWidth
+	}
+	if height < MinTerminalHeight {
+		height = MinTerminalHeight
+	}
+
 	v.TerminalWidth = width
 	v.TerminalHeight = height
 

--- a/internal/ui/modals/state_test.go
+++ b/internal/ui/modals/state_test.go
@@ -1,0 +1,412 @@
+package modals
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// =============================================================================
+// HelpState Tests
+// =============================================================================
+
+func TestNewHelpStateFromSections(t *testing.T) {
+	sections := []HelpSection{
+		{
+			Title: "Navigation",
+			Shortcuts: []HelpShortcut{
+				{Key: "tab", Desc: "switch pane"},
+				{Key: "up/down", Desc: "navigate"},
+			},
+		},
+		{
+			Title: "Actions",
+			Shortcuts: []HelpShortcut{
+				{Key: "enter", Desc: "confirm"},
+				{Key: "esc", Desc: "cancel"},
+			},
+		},
+	}
+
+	state := NewHelpStateFromSections(sections)
+
+	if len(state.Sections) != 2 {
+		t.Errorf("expected 2 sections, got %d", len(state.Sections))
+	}
+
+	if len(state.FlatShortcuts) != 4 {
+		t.Errorf("expected 4 flattened shortcuts, got %d", len(state.FlatShortcuts))
+	}
+
+	if state.SelectedIndex != 0 {
+		t.Errorf("expected initial selected index to be 0, got %d", state.SelectedIndex)
+	}
+
+	if state.ScrollOffset != 0 {
+		t.Errorf("expected initial scroll offset to be 0, got %d", state.ScrollOffset)
+	}
+}
+
+func TestHelpState_Title(t *testing.T) {
+	state := &HelpState{}
+	if state.Title() != "Keyboard Shortcuts" {
+		t.Errorf("expected title 'Keyboard Shortcuts', got '%s'", state.Title())
+	}
+}
+
+func TestHelpState_Help(t *testing.T) {
+	state := &HelpState{}
+	help := state.Help()
+	if help == "" {
+		t.Error("expected non-empty help text")
+	}
+}
+
+func TestHelpState_Update_Navigation(t *testing.T) {
+	sections := []HelpSection{
+		{
+			Title: "Test",
+			Shortcuts: []HelpShortcut{
+				{Key: "a", Desc: "action a"},
+				{Key: "b", Desc: "action b"},
+				{Key: "c", Desc: "action c"},
+			},
+		},
+	}
+	state := NewHelpStateFromSections(sections)
+
+	// Test down navigation
+	keyDownMsg := tea.KeyPressMsg{Code: 0, Text: "down"}
+	newState, _ := state.Update(keyDownMsg)
+	if s, ok := newState.(*HelpState); ok {
+		if s.SelectedIndex != 1 {
+			t.Errorf("expected selected index 1 after down, got %d", s.SelectedIndex)
+		}
+	}
+
+	// Test up navigation
+	keyUpMsg := tea.KeyPressMsg{Code: 0, Text: "up"}
+	newState, _ = state.Update(keyUpMsg)
+	if s, ok := newState.(*HelpState); ok {
+		if s.SelectedIndex != 0 {
+			t.Errorf("expected selected index 0 after up, got %d", s.SelectedIndex)
+		}
+	}
+
+	// Test up at start (should stay at 0)
+	newState, _ = state.Update(keyUpMsg)
+	if s, ok := newState.(*HelpState); ok {
+		if s.SelectedIndex != 0 {
+			t.Errorf("expected selected index to stay 0 when at start, got %d", s.SelectedIndex)
+		}
+	}
+}
+
+func TestHelpState_Update_NavigationBounds(t *testing.T) {
+	sections := []HelpSection{
+		{
+			Title: "Test",
+			Shortcuts: []HelpShortcut{
+				{Key: "a", Desc: "action a"},
+				{Key: "b", Desc: "action b"},
+			},
+		},
+	}
+	state := NewHelpStateFromSections(sections)
+
+	// Navigate to the end
+	keyDownMsg := tea.KeyPressMsg{Code: 0, Text: "down"}
+	state.Update(keyDownMsg) // Now at 1
+
+	// Try to go past the end
+	state.Update(keyDownMsg)
+	if state.SelectedIndex != 1 {
+		t.Errorf("expected selected index to stay at 1 when at end, got %d", state.SelectedIndex)
+	}
+}
+
+func TestHelpState_GetSelectedShortcut(t *testing.T) {
+	sections := []HelpSection{
+		{
+			Title: "Test",
+			Shortcuts: []HelpShortcut{
+				{Key: "a", Desc: "action a"},
+				{Key: "b", Desc: "action b"},
+			},
+		},
+	}
+	state := NewHelpStateFromSections(sections)
+
+	shortcut := state.GetSelectedShortcut()
+	if shortcut == nil {
+		t.Fatal("expected non-nil shortcut")
+	}
+	if shortcut.Key != "a" {
+		t.Errorf("expected key 'a', got '%s'", shortcut.Key)
+	}
+
+	// Navigate and check again
+	keyDownMsg := tea.KeyPressMsg{Code: 0, Text: "down"}
+	state.Update(keyDownMsg)
+
+	shortcut = state.GetSelectedShortcut()
+	if shortcut == nil {
+		t.Fatal("expected non-nil shortcut after navigation")
+	}
+	if shortcut.Key != "b" {
+		t.Errorf("expected key 'b', got '%s'", shortcut.Key)
+	}
+}
+
+func TestHelpState_GetSelectedShortcut_Empty(t *testing.T) {
+	state := &HelpState{
+		FlatShortcuts: []HelpShortcut{},
+		SelectedIndex: 0,
+	}
+
+	shortcut := state.GetSelectedShortcut()
+	if shortcut != nil {
+		t.Error("expected nil shortcut for empty list")
+	}
+}
+
+func TestHelpState_Render(t *testing.T) {
+	sections := []HelpSection{
+		{
+			Title: "Navigation",
+			Shortcuts: []HelpShortcut{
+				{Key: "tab", Desc: "switch pane"},
+			},
+		},
+	}
+	state := NewHelpStateFromSections(sections)
+
+	rendered := state.Render()
+	if rendered == "" {
+		t.Error("expected non-empty rendered output")
+	}
+}
+
+// =============================================================================
+// AddRepoState Tests
+// =============================================================================
+
+func TestNewAddRepoState_WithSuggestion(t *testing.T) {
+	state := NewAddRepoState("/some/path")
+
+	if state.SuggestedRepo != "/some/path" {
+		t.Errorf("expected suggested repo '/some/path', got '%s'", state.SuggestedRepo)
+	}
+	if !state.UseSuggested {
+		t.Error("expected UseSuggested to be true when suggestion provided")
+	}
+}
+
+func TestNewAddRepoState_NoSuggestion(t *testing.T) {
+	state := NewAddRepoState("")
+
+	if state.SuggestedRepo != "" {
+		t.Errorf("expected empty suggested repo, got '%s'", state.SuggestedRepo)
+	}
+	if state.UseSuggested {
+		t.Error("expected UseSuggested to be false when no suggestion")
+	}
+}
+
+func TestAddRepoState_Title(t *testing.T) {
+	state := NewAddRepoState("")
+	if state.Title() != "Add Repository" {
+		t.Errorf("expected title 'Add Repository', got '%s'", state.Title())
+	}
+}
+
+func TestAddRepoState_GetPath_UseSuggested(t *testing.T) {
+	state := NewAddRepoState("/suggested/path")
+	state.UseSuggested = true
+
+	path := state.GetPath()
+	if path != "/suggested/path" {
+		t.Errorf("expected path '/suggested/path', got '%s'", path)
+	}
+}
+
+func TestAddRepoState_GetPath_UseInput(t *testing.T) {
+	state := NewAddRepoState("/suggested/path")
+	state.UseSuggested = false
+	state.Input.SetValue("/custom/path")
+
+	path := state.GetPath()
+	if path != "/custom/path" {
+		t.Errorf("expected path '/custom/path', got '%s'", path)
+	}
+}
+
+func TestAddRepoState_Update_ToggleSuggestion(t *testing.T) {
+	state := NewAddRepoState("/suggested/path")
+	state.UseSuggested = true
+
+	// Press down to toggle
+	keyDownMsg := tea.KeyPressMsg{Code: 0, Text: "down"}
+	state.Update(keyDownMsg)
+
+	if state.UseSuggested {
+		t.Error("expected UseSuggested to toggle to false")
+	}
+
+	// Press up to toggle back
+	keyUpMsg := tea.KeyPressMsg{Code: 0, Text: "up"}
+	state.Update(keyUpMsg)
+
+	if !state.UseSuggested {
+		t.Error("expected UseSuggested to toggle back to true")
+	}
+}
+
+func TestAddRepoState_Render(t *testing.T) {
+	state := NewAddRepoState("/test/path")
+	rendered := state.Render()
+
+	if rendered == "" {
+		t.Error("expected non-empty rendered output")
+	}
+}
+
+func TestAddRepoState_IsShowingOptions(t *testing.T) {
+	state := NewAddRepoState("")
+
+	if state.IsShowingOptions() {
+		t.Error("expected IsShowingOptions to be false initially")
+	}
+
+	state.showingOptions = true
+	if !state.IsShowingOptions() {
+		t.Error("expected IsShowingOptions to be true after setting")
+	}
+}
+
+// =============================================================================
+// SelectRepoForIssuesState Tests
+// =============================================================================
+
+func TestNewSelectRepoForIssuesState(t *testing.T) {
+	repos := []string{"/repo1", "/repo2", "/repo3"}
+	state := NewSelectRepoForIssuesState(repos)
+
+	if len(state.RepoOptions) != 3 {
+		t.Errorf("expected 3 repos, got %d", len(state.RepoOptions))
+	}
+	if state.RepoIndex != 0 {
+		t.Errorf("expected initial index 0, got %d", state.RepoIndex)
+	}
+}
+
+func TestSelectRepoForIssuesState_Title(t *testing.T) {
+	state := NewSelectRepoForIssuesState(nil)
+	if state.Title() != "Select Repository" {
+		t.Errorf("expected title 'Select Repository', got '%s'", state.Title())
+	}
+}
+
+func TestSelectRepoForIssuesState_GetSelectedRepo(t *testing.T) {
+	repos := []string{"/repo1", "/repo2"}
+	state := NewSelectRepoForIssuesState(repos)
+
+	selected := state.GetSelectedRepo()
+	if selected != "/repo1" {
+		t.Errorf("expected '/repo1', got '%s'", selected)
+	}
+
+	state.RepoIndex = 1
+	selected = state.GetSelectedRepo()
+	if selected != "/repo2" {
+		t.Errorf("expected '/repo2', got '%s'", selected)
+	}
+}
+
+func TestSelectRepoForIssuesState_GetSelectedRepo_Empty(t *testing.T) {
+	state := NewSelectRepoForIssuesState([]string{})
+
+	selected := state.GetSelectedRepo()
+	if selected != "" {
+		t.Errorf("expected empty string for empty list, got '%s'", selected)
+	}
+}
+
+func TestSelectRepoForIssuesState_Update_Navigation(t *testing.T) {
+	repos := []string{"/repo1", "/repo2", "/repo3"}
+	state := NewSelectRepoForIssuesState(repos)
+
+	// Navigate down
+	keyDownMsg := tea.KeyPressMsg{Code: 0, Text: "down"}
+	state.Update(keyDownMsg)
+	if state.RepoIndex != 1 {
+		t.Errorf("expected index 1 after down, got %d", state.RepoIndex)
+	}
+
+	// Navigate up
+	keyUpMsg := tea.KeyPressMsg{Code: 0, Text: "up"}
+	state.Update(keyUpMsg)
+	if state.RepoIndex != 0 {
+		t.Errorf("expected index 0 after up, got %d", state.RepoIndex)
+	}
+
+	// Up at start should stay at 0
+	state.Update(keyUpMsg)
+	if state.RepoIndex != 0 {
+		t.Errorf("expected index to stay 0 at start, got %d", state.RepoIndex)
+	}
+}
+
+func TestSelectRepoForIssuesState_Render(t *testing.T) {
+	repos := []string{"/repo1", "/repo2"}
+	state := NewSelectRepoForIssuesState(repos)
+
+	rendered := state.Render()
+	if rendered == "" {
+		t.Error("expected non-empty rendered output")
+	}
+}
+
+func TestSelectRepoForIssuesState_Render_Empty(t *testing.T) {
+	state := NewSelectRepoForIssuesState([]string{})
+
+	rendered := state.Render()
+	if rendered == "" {
+		t.Error("expected non-empty rendered output even with no repos")
+	}
+}
+
+// =============================================================================
+// Helper function tests
+// =============================================================================
+
+func TestFormatInt(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{10, "10"},
+		{123, "123"},
+		{9999, "9999"},
+	}
+
+	for _, tt := range tests {
+		result := formatInt(tt.input)
+		if result != tt.expected {
+			t.Errorf("formatInt(%d) = %s, expected %s", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// =============================================================================
+// Type assertion tests - ensure all modal states implement ModalState
+// =============================================================================
+
+func TestModalStateInterface(t *testing.T) {
+	// These compile-time checks verify interface implementation
+	var _ ModalState = (*HelpState)(nil)
+	var _ ModalState = (*AddRepoState)(nil)
+	var _ ModalState = (*SelectRepoForIssuesState)(nil)
+}

--- a/internal/ui/text_selection.go
+++ b/internal/ui/text_selection.go
@@ -20,6 +20,11 @@ type SelectionCopyMsg struct {
 	x, y         int
 }
 
+// ClipboardErrorMsg is sent when clipboard operations fail
+type ClipboardErrorMsg struct {
+	Error error
+}
+
 const (
 	doubleClickThreshold = 500 * time.Millisecond
 	clickTolerance       = 2 // pixels
@@ -283,10 +288,11 @@ func (c *Chat) CopySelectedText() tea.Cmd {
 	return tea.Batch(
 		// OSC 52 escape sequence (works in modern terminals)
 		tea.SetClipboard(selectedText),
-		// Native clipboard fallback
+		// Native clipboard fallback - returns error message if it fails
 		func() tea.Msg {
 			if err := clipboard.WriteText(selectedText); err != nil {
 				logger.Log("Failed to write to clipboard: %v", err)
+				return ClipboardErrorMsg{Error: err}
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary
This PR adds thread-safety improvements to the SessionManager's runner map access and fixes several UI-related issues including clipboard error handling, terminal resize behavior, and message cache invalidation.

## Changes
- Add `sync.RWMutex` to protect the `runners` map in SessionManager, preventing race conditions during concurrent session operations
- Return a copy of runners map from `GetRunners()` to enable safe iteration
- Add proper locking around all runner map operations (get, set, delete, iterate)
- Rename `SessionStateManager.Get()` to `GetOrCreate()` for clarity
- Add `ClipboardErrorMsg` type and handle clipboard write failures with user-visible flash messages
- Invalidate message cache when viewport width changes during terminal resize
- Add minimum terminal size constants (`MinTerminalWidth`, `MinTerminalHeight`) to prevent negative layout values
- Add validation in `UpdateTerminalSize()` to enforce minimum dimensions
- Add documentation comments for MCP channel architecture and ProcessCallbacks threading model
- Add comprehensive tests for modal state types

## Test plan
- Run `go test ./...` to verify all tests pass
- Test concurrent session operations (create, delete, switch between sessions rapidly)
- Test terminal resizing - messages should re-render correctly at new widths
- Test clipboard copy failure handling (e.g., in a headless environment) - should show error flash message
- Test with very small terminal sizes - should not panic or show corrupted layout