### PR TITLE
Refactor mouse coordinate adjustment into helper methods

### DIFF
--- a/internal/app/testutil_test.go
+++ b/internal/app/testutil_test.go
@@ -332,3 +332,34 @@ func testFileDiffs() []git.FileDiff {
 		},
 	}
 }
+
+// =============================================================================
+// Mouse Event Helpers
+// =============================================================================
+
+// mouseClick creates a tea.MouseClickMsg at the given coordinates.
+func mouseClick(x, y int) tea.MouseClickMsg {
+	return tea.MouseClickMsg{
+		X:      x,
+		Y:      y,
+		Button: tea.MouseLeft,
+	}
+}
+
+// mouseMotion creates a tea.MouseMotionMsg at the given coordinates.
+func mouseMotion(x, y int) tea.MouseMotionMsg {
+	return tea.MouseMotionMsg{
+		X:      x,
+		Y:      y,
+		Button: tea.MouseLeft,
+	}
+}
+
+// mouseRelease creates a tea.MouseReleaseMsg at the given coordinates.
+func mouseRelease(x, y int) tea.MouseReleaseMsg {
+	return tea.MouseReleaseMsg{
+		X:      x,
+		Y:      y,
+		Button: tea.MouseLeft,
+	}
+}


### PR DESCRIPTION
## Summary
Extract duplicated mouse coordinate adjustment logic into reusable helper methods, improving code maintainability and reducing repetition in the Update function.

## Changes
- Add `adjustMouseForChat()` method that checks if a mouse event is in the chat panel area and adjusts coordinates relative to the chat panel
- Add `routeMouseToChat()` method that combines coordinate adjustment with routing the event to the chat panel
- Replace ~80 lines of duplicated mouse handling code with calls to the new helper methods
- Add comprehensive unit tests for mouse coordinate adjustment logic
- Add test helper functions for creating mouse events (`mouseClick`, `mouseMotion`, `mouseRelease`)

## Test plan
- Run `go test ./internal/app/...` to verify all existing and new tests pass
- New tests cover:
  - Click events in chat area (coordinates adjusted correctly)
  - Click events in sidebar area (not handled)
  - Motion events with coordinate adjustment
  - Release events with coordinate adjustment
  - Unsupported event types (not handled)
  - Integration test for the full routing flow