### PR TITLE
Unify permission, question, and plan approval request handlers

### DIFF
--- a/internal/app/testutil_test.go
+++ b/internal/app/testutil_test.go
@@ -218,6 +218,19 @@ func simulateQuestionRequest(m *Model, sessionID string, questions []mcp.Questio
 	return result.(*Model)
 }
 
+// simulatePlanApprovalRequest injects a PlanApprovalRequestMsg into the model.
+func simulatePlanApprovalRequest(m *Model, sessionID, plan string, allowedPrompts []mcp.AllowedPrompt) *Model {
+	msg := PlanApprovalRequestMsg{
+		SessionID: sessionID,
+		Request: mcp.PlanApprovalRequest{
+			Plan:           plan,
+			AllowedPrompts: allowedPrompts,
+		},
+	}
+	result, _ := m.Update(msg)
+	return result.(*Model)
+}
+
 // =============================================================================
 // Response Building Helpers
 // =============================================================================


### PR DESCRIPTION
## Summary
Refactors the three separate handlers for Claude prompt requests (permissions, questions, and plan approvals) into a single unified handler, reducing code duplication and improving maintainability.

## Changes
- Add `PromptRequestType` enum and `PromptRequest` unified struct to represent all three prompt types
- Create `handlePromptRequest()` method that handles the common logic for all prompt types
- Refactor `handlePermissionRequestMsg`, `handleQuestionRequestMsg`, and `handlePlanApprovalRequestMsg` to delegate to the unified handler
- Add comprehensive integration tests for plan approval flow (approve/reject)
- Add tests verifying the unified handler works correctly for all three prompt types
- Add `simulatePlanApprovalRequest` test helper

## Test plan
- Run `go test ./internal/app/...` to verify all tests pass
- New tests cover:
  - Full plan approval flow (approve with 'y')
  - Full plan rejection flow (reject with 'n')
  - Plan approval only works from chat focus
  - Unified handler handles unknown sessions gracefully
  - All three prompt types correctly set sidebar indicator