### PR TITLE
Add mutex protection for activeSession field

### DIFF
--- a/internal/app/modal_handlers_git.go
+++ b/internal/app/modal_handlers_git.go
@@ -37,7 +37,8 @@ func (m *Model) handleMergeModal(key string, msg tea.KeyPressMsg, state *ui.Merg
 		}
 		logger.Log("App: Starting merge operation: option=%q, session=%s, branch=%s, worktree=%s", option, sess.ID, sess.Branch, sess.WorkTree)
 		m.modal.Hide()
-		if m.activeSession == nil || m.activeSession.ID != sess.ID {
+		activeSession := m.getActiveSession()
+		if activeSession == nil || activeSession.ID != sess.ID {
 			m.selectSession(sess)
 		}
 
@@ -262,7 +263,8 @@ func (m *Model) handleClaudeResolveConflict(state *ui.MergeConflictState) (tea.M
 	}
 
 	// Make sure this session is active
-	if m.activeSession == nil || m.activeSession.ID != sess.ID {
+	activeSession := m.getActiveSession()
+	if activeSession == nil || activeSession.ID != sess.ID {
 		m.selectSession(sess)
 	}
 

--- a/internal/app/modal_handlers_github.go
+++ b/internal/app/modal_handlers_github.go
@@ -217,11 +217,12 @@ type parallelSessionInfo struct {
 
 // createParallelSessions creates new sessions for each selected option, pre-populated with history.
 func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Model, tea.Cmd) {
-	if m.activeSession == nil || m.claudeRunner == nil {
+	activeSession := m.getActiveSession()
+	if activeSession == nil || m.claudeRunner == nil {
 		return m, nil
 	}
 
-	parentSession := m.activeSession
+	parentSession := activeSession
 	parentMessages := m.claudeRunner.GetMessages()
 
 	logger.Log("App: Creating %d parallel sessions from session %s", len(selectedOptions), parentSession.ID)

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -133,19 +133,19 @@ func (m *Model) handleConfirmDeleteModal(key string, msg tea.KeyPressMsg, state 
 			// Clean up runner and all per-session state via SessionManager
 			deletedRunner := m.sessionMgr.DeleteSession(sess.ID)
 			m.sidebar.SetPendingPermission(sess.ID, false)
+			activeSession := m.getActiveSession()
 			logger.Log("App: Checking if active session should be cleared: activeSession=%v, activeSessionID=%s, deletedSessionID=%s",
-				m.activeSession != nil,
+				activeSession != nil,
 				func() string {
-					if m.activeSession != nil {
-						return m.activeSession.ID
-					} else {
-						return "<nil>"
+					if activeSession != nil {
+						return activeSession.ID
 					}
+					return "<nil>"
 				}(),
 				sess.ID)
-			if m.activeSession != nil && m.activeSession.ID == sess.ID {
+			if activeSession != nil && activeSession.ID == sess.ID {
 				logger.Log("App: Clearing active session and chat")
-				m.activeSession = nil
+				m.setActiveSession(nil)
 				m.claudeRunner = nil
 				m.chat.ClearSession()
 				m.header.SetSessionName("")
@@ -318,9 +318,10 @@ func (m *Model) handleRenameSessionModal(key string, msg tea.KeyPressMsg, state 
 
 		// Update sidebar and header
 		m.sidebar.SetSessions(m.config.GetSessions())
-		if m.activeSession != nil && m.activeSession.ID == state.SessionID {
-			m.activeSession.Name = newBranch
-			m.activeSession.Branch = newBranch
+		activeSession := m.getActiveSession()
+		if activeSession != nil && activeSession.ID == state.SessionID {
+			activeSession.Name = newBranch
+			activeSession.Branch = newBranch
 			m.header.SetSessionName(newBranch)
 		}
 		m.modal.Hide()

--- a/internal/app/msg_handlers.go
+++ b/internal/app/msg_handlers.go
@@ -22,7 +22,7 @@ func (m *Model) handleClaudeResponseMsg(msg ClaudeResponseMsg) (tea.Model, tea.C
 		return m, nil
 	}
 
-	isActiveSession := m.activeSession != nil && m.activeSession.ID == msg.SessionID
+	isActiveSession := m.getActiveSessionID() == msg.SessionID
 
 	if msg.Chunk.Error != nil {
 		return m.handleClaudeError(msg.SessionID, msg.Chunk.Error.Error(), isActiveSession)
@@ -214,7 +214,7 @@ func (m *Model) handleNonActiveSessionStreaming(sessionID string, chunk claude.R
 
 // handleMergeResultMsg handles merge operation results.
 func (m *Model) handleMergeResultMsg(msg MergeResultMsg) (tea.Model, tea.Cmd) {
-	isActiveSession := m.activeSession != nil && m.activeSession.ID == msg.SessionID
+	isActiveSession := m.getActiveSessionID() == msg.SessionID
 
 	if msg.Result.Error != nil {
 		return m.handleMergeError(msg.SessionID, msg.Result, isActiveSession)
@@ -350,7 +350,7 @@ func (m *Model) handleSendPendingMessageMsg(msg SendPendingMessageMsg) (tea.Mode
 	logger.Log("App: Sending pending message for session %s: %s", msg.SessionID, pendingMsg)
 
 	// If this is the active session, add to chat and clear queued display
-	isActiveSession := m.activeSession != nil && m.activeSession.ID == msg.SessionID
+	isActiveSession := m.getActiveSessionID() == msg.SessionID
 	if isActiveSession {
 		m.chat.ClearQueuedMessage()
 		m.chat.AddUserMessage(pendingMsg)
@@ -393,7 +393,7 @@ func (m *Model) handlePermissionRequestMsg(msg PermissionRequestMsg) (tea.Model,
 	m.sidebar.SetPendingPermission(msg.SessionID, true)
 
 	// If this is the active session, show permission in chat
-	if m.activeSession != nil && m.activeSession.ID == msg.SessionID {
+	if m.getActiveSessionID() == msg.SessionID {
 		m.chat.SetPendingPermission(msg.Request.Tool, msg.Request.Description)
 	}
 
@@ -417,7 +417,7 @@ func (m *Model) handleQuestionRequestMsg(msg QuestionRequestMsg) (tea.Model, tea
 	m.sidebar.SetPendingPermission(msg.SessionID, true) // Reuse permission indicator for questions
 
 	// If this is the active session, show question in chat
-	if m.activeSession != nil && m.activeSession.ID == msg.SessionID {
+	if m.getActiveSessionID() == msg.SessionID {
 		m.chat.SetPendingQuestion(msg.Request.Questions)
 	}
 
@@ -442,7 +442,7 @@ func (m *Model) handlePlanApprovalRequestMsg(msg PlanApprovalRequestMsg) (tea.Mo
 	m.sidebar.SetPendingPermission(msg.SessionID, true) // Reuse permission indicator for plan approval
 
 	// If this is the active session, show plan approval in chat
-	if m.activeSession != nil && m.activeSession.ID == msg.SessionID {
+	if m.getActiveSessionID() == msg.SessionID {
 		m.chat.SetPendingPlanApproval(msg.Request.Plan, msg.Request.AllowedPrompts)
 	}
 

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -414,8 +414,9 @@ func shortcutRenameSession(m *Model) (tea.Model, tea.Cmd) {
 func shortcutOpenTerminal(m *Model) (tea.Model, tea.Cmd) {
 	// Use activeSession when chat is focused, otherwise use sidebar selection
 	var sess *config.Session
-	if m.chat.IsFocused() && m.activeSession != nil {
-		sess = m.activeSession
+	activeSession := m.getActiveSession()
+	if m.chat.IsFocused() && activeSession != nil {
+		sess = activeSession
 	} else {
 		sess = m.sidebar.SelectedSession()
 	}
@@ -429,7 +430,8 @@ func shortcutOpenTerminal(m *Model) (tea.Model, tea.Cmd) {
 func shortcutViewChanges(m *Model) (tea.Model, tea.Cmd) {
 	sess := m.sidebar.SelectedSession()
 	// Select the session first so we can display in its chat panel
-	if m.activeSession == nil || m.activeSession.ID != sess.ID {
+	activeSession := m.getActiveSession()
+	if activeSession == nil || activeSession.ID != sess.ID {
 		m.selectSession(sess)
 	}
 	// Get worktree status and display it in view changes overlay

--- a/internal/app/slash_commands.go
+++ b/internal/app/slash_commands.go
@@ -155,15 +155,16 @@ type sessionJSONLEntry struct {
 
 // handleCostCommand shows token usage and estimated cost for the current session.
 func handleCostCommand(m *Model, _ string) SlashCommandResult {
-	if m.activeSession == nil {
+	activeSession := m.getActiveSession()
+	if activeSession == nil {
 		return SlashCommandResult{
 			Handled:  true,
 			Response: "No active session. Create or select a session first.",
 		}
 	}
 
-	sessionID := m.activeSession.ID
-	workingDir := m.activeSession.WorkTree
+	sessionID := activeSession.ID
+	workingDir := activeSession.WorkTree
 
 	// Find the Claude session JSONL file
 	stats, err := getSessionUsageStats(sessionID, workingDir)


### PR DESCRIPTION
## Summary
Adds thread-safe access to the `activeSession` field in the app model by introducing a `sync.RWMutex` to protect concurrent reads and writes.

## Changes
- Add `activeSessionMu sync.RWMutex` to protect the `activeSession` field
- Create `setActiveSession()` method for thread-safe writes
- Create `getActiveSession()` method for thread-safe reads within the Update loop
- Create `getActiveSessionID()` convenience method for safely getting session ID
- Update `ActiveSession()` public method to use proper locking
- Refactor all internal access to `activeSession` to use the new thread-safe methods
- Update `RenderToString()` to get session info with proper locking before use

## Test plan
- Run `go test ./...` to verify all existing tests pass
- Verify the app runs correctly with `go run . --debug`
- Test session switching, deletion, and concurrent operations
- Check that forking sessions and parallel session creation work correctly