### PR TITLE
Remove response read timeout from ProcessManager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,11 +322,6 @@ Key interfaces:
 
 The ProcessManager (`internal/claude/process_manager.go`) implements robust error handling:
 
-**Response Read Timeout** (2 minutes):
-- Prevents UI freeze when Claude process hangs mid-response
-- Uses goroutine-based timeout on `ReadString()` calls
-- On timeout, kills the hung process and reports error to user
-
 **Response Channel Full Handling**:
 - When the response channel is full for >10 seconds, reports error instead of silently dropping chunks
 - User sees `[Error: Response buffer full - some output may be lost]` message
@@ -344,7 +339,6 @@ The ProcessManager (`internal/claude/process_manager.go`) implements robust erro
 
 Constants in `internal/claude/claude.go`:
 ```go
-ResponseReadTimeout = 2 * time.Minute       // Timeout for hung process detection
 MaxProcessRestartAttempts = 3               // Max auto-restart attempts
 ProcessRestartDelay = 500 * time.Millisecond // Delay between restarts
 ResponseChannelFullTimeout = 10 * time.Second // Before reporting full channel

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -1034,10 +1034,6 @@ func TestRunner_Interrupt_Idempotent(t *testing.T) {
 
 func TestConstants(t *testing.T) {
 	// Verify error handling constants have reasonable values
-	if ResponseReadTimeout <= 0 {
-		t.Error("ResponseReadTimeout should be positive")
-	}
-
 	if MaxProcessRestartAttempts <= 0 {
 		t.Error("MaxProcessRestartAttempts should be positive")
 	}
@@ -1159,19 +1155,11 @@ func TestHandleFatalError_NilChannel(t *testing.T) {
 
 func TestErrorVariables(t *testing.T) {
 	// Verify error variables are defined
-	if errReadTimeout == nil {
-		t.Error("errReadTimeout should not be nil")
-	}
-
 	if errChannelFull == nil {
 		t.Error("errChannelFull should not be nil")
 	}
 
 	// Verify they have meaningful messages
-	if errReadTimeout.Error() == "" {
-		t.Error("errReadTimeout should have a message")
-	}
-
 	if errChannelFull.Error() == "" {
 		t.Error("errChannelFull should have a message")
 	}

--- a/internal/claude/process_manager_test.go
+++ b/internal/claude/process_manager_test.go
@@ -282,12 +282,11 @@ func TestProcessConfig_Fields(t *testing.T) {
 
 func TestProcessCallbacks_AllFields(t *testing.T) {
 	var (
-		onLineCalled          int32
-		onProcessExitCalled   int32
-		onProcessHungCalled   int32
+		onLineCalled           int32
+		onProcessExitCalled    int32
 		onRestartAttemptCalled int32
 		onRestartFailedCalled  int32
-		onFatalErrorCalled    int32
+		onFatalErrorCalled     int32
 	)
 
 	callbacks := ProcessCallbacks{
@@ -297,9 +296,6 @@ func TestProcessCallbacks_AllFields(t *testing.T) {
 		OnProcessExit: func(err error, stderrContent string) bool {
 			atomic.AddInt32(&onProcessExitCalled, 1)
 			return false
-		},
-		OnProcessHung: func() {
-			atomic.AddInt32(&onProcessHungCalled, 1)
 		},
 		OnRestartAttempt: func(attemptNum int) {
 			atomic.AddInt32(&onRestartAttemptCalled, 1)
@@ -322,12 +318,6 @@ func TestProcessCallbacks_AllFields(t *testing.T) {
 	callbacks.OnProcessExit(nil, "")
 	if atomic.LoadInt32(&onProcessExitCalled) != 1 {
 		t.Error("OnProcessExit callback not called")
-	}
-
-	// Test OnProcessHung
-	callbacks.OnProcessHung()
-	if atomic.LoadInt32(&onProcessHungCalled) != 1 {
-		t.Error("OnProcessHung callback not called")
 	}
 
 	// Test OnRestartAttempt
@@ -359,7 +349,6 @@ func TestProcessCallbacks_NilCallbacks(t *testing.T) {
 	// These should not panic even when callbacks are nil
 	pm.callbacks.OnLine = nil
 	pm.callbacks.OnProcessExit = nil
-	pm.callbacks.OnProcessHung = nil
 	pm.callbacks.OnRestartAttempt = nil
 	pm.callbacks.OnRestartFailed = nil
 	pm.callbacks.OnFatalError = nil
@@ -377,16 +366,8 @@ func TestProcessManagerInterface_Compliance(t *testing.T) {
 
 func TestErrorVariables_ProcessManager(t *testing.T) {
 	// Verify error variables defined in process_manager.go
-	if errReadTimeout == nil {
-		t.Error("errReadTimeout should not be nil")
-	}
-
 	if errChannelFull == nil {
 		t.Error("errChannelFull should not be nil")
-	}
-
-	if errReadTimeout.Error() == "" {
-		t.Error("errReadTimeout should have a message")
 	}
 
 	if errChannelFull.Error() == "" {
@@ -464,14 +445,6 @@ func TestProcessManager_Constants(t *testing.T) {
 
 	if ProcessRestartDelay <= 0 {
 		t.Error("ProcessRestartDelay should be positive")
-	}
-
-	if ResponseReadTimeout <= 0 {
-		t.Error("ResponseReadTimeout should be positive")
-	}
-
-	if ResponseReadTimeout < time.Minute {
-		t.Error("ResponseReadTimeout should be at least 1 minute")
 	}
 }
 
@@ -901,3 +874,4 @@ func TestProcessManager_GoroutineExitOnContextCancel(t *testing.T) {
 		t.Error("WaitGroup.Wait() blocked after goroutine exit")
 	}
 }
+

--- a/internal/mcp/socket_test.go
+++ b/internal/mcp/socket_test.go
@@ -461,3 +461,4 @@ func contains(s, substr string) bool {
 	}
 	return false
 }
+


### PR DESCRIPTION
The 2-minute read timeout was causing issues by prematurely killing Claude processes that were legitimately taking time to think. Claude's thinking time can exceed 2 minutes for complex tasks.

This preserves the other safety mechanisms:
- Process crash detection and auto-recovery
- Response channel full detection
- Proper cleanup on context cancellation