### PR TITLE
Extract magic numbers into named constants

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -279,8 +279,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Debug: log paste content to understand what's being pasted
 		content := msg.Content
 		preview := content
-		if len(preview) > 100 {
-			preview = preview[:100] + "..."
+		if len(preview) > ui.PasteContentPreviewLen {
+			preview = preview[:ui.PasteContentPreviewLen] + "..."
 		}
 		logger.Log("App: PasteMsg received: len=%d, preview=%q", len(content), preview)
 
@@ -1025,8 +1025,8 @@ func (m *Model) sendMessage() (tea.Model, tea.Cmd) {
 	}
 
 	inputPreview := input
-	if len(inputPreview) > 50 {
-		inputPreview = inputPreview[:50] + "..."
+	if len(inputPreview) > ui.InputMessagePreviewLen {
+		inputPreview = inputPreview[:ui.InputMessagePreviewLen] + "..."
 	}
 	logger.Log("App: Sending message to session %s: %q, hasImage=%v", m.activeSession.ID, inputPreview, hasImage)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -35,6 +35,10 @@ const (
 	// commit message generation and rarely provide additional value.
 	// 50KB is enough to capture meaningful changes while staying responsive.
 	MaxDiffSize = 50000
+
+	// MaxBranchNameLength is the maximum length for auto-generated branch names.
+	// User-provided branch names can be longer (up to MaxBranchNameValidation).
+	MaxBranchNameLength = 50
 )
 
 // Result represents output from a git operation
@@ -945,8 +949,8 @@ func sanitizeBranchName(name string) string {
 	name = strings.Trim(name, "-")
 
 	// Truncate if too long
-	if len(name) > 50 {
-		name = name[:50]
+	if len(name) > MaxBranchNameLength {
+		name = name[:MaxBranchNameLength]
 		// Don't end with a hyphen
 		name = strings.TrimRight(name, "-")
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -41,6 +41,10 @@ const (
 	BasePointHead BasePoint = "head"
 )
 
+// MaxBranchNameValidation is the maximum length for user-provided branch names.
+// This is more permissive than git.MaxBranchNameLength which is for auto-generated names.
+const MaxBranchNameValidation = 100
+
 // validBranchNameRegex matches valid git branch name characters
 // Git branch names cannot contain: space, ~, ^, :, ?, *, [, \, or control characters
 // They also cannot start with - or end with .lock
@@ -52,8 +56,8 @@ func ValidateBranchName(branch string) error {
 		return nil // Empty is allowed (will use default)
 	}
 
-	if len(branch) > 100 {
-		return fmt.Errorf("branch name too long (max 100 characters)")
+	if len(branch) > MaxBranchNameValidation {
+		return fmt.Errorf("branch name too long (max %d characters)", MaxBranchNameValidation)
 	}
 
 	if strings.HasPrefix(branch, "-") {

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -577,8 +577,8 @@ func (c *Chat) SetTodoList(list *pclaude.TodoList) {
 	if list != nil && list.IsComplete() {
 		// Bake the completed todo list into messages as rendered content
 		wrapWidth := c.viewport.Width()
-		if wrapWidth < 20 {
-			wrapWidth = 80 // Fallback if viewport not initialized
+		if wrapWidth < TodoListMinWrapWidth {
+			wrapWidth = TodoListFallbackWrapWidth
 		}
 		renderedTodo := renderTodoList(list, wrapWidth)
 		c.messages = append(c.messages, pclaude.Message{
@@ -746,7 +746,7 @@ func (c *Chat) renderPlanApprovalPrompt(wrapWidth int) string {
 	// Render plan as markdown
 	renderedPlan := renderMarkdown(c.pendingPlan, wrapWidth-4) // -4 for box padding
 	planLines := strings.Split(renderedPlan, "\n")
-	maxVisibleLines := 20 // Maximum lines to show at once
+	maxVisibleLines := PlanApprovalMaxVisible
 
 	// Calculate visible range
 	startLine := c.planScrollOffset

--- a/internal/ui/chat_render.go
+++ b/internal/ui/chat_render.go
@@ -46,12 +46,12 @@ func highlightCode(code, language string) string {
 	}
 	lexer = chroma.Coalesce(lexer)
 
-	style := styles.Get("monokai")
+	style := styles.Get(DefaultSyntaxStyle)
 	if style == nil {
 		style = styles.Fallback
 	}
 
-	formatter := formatters.Get("terminal256")
+	formatter := formatters.Get(DefaultTerminalFormatter)
 	if formatter == nil {
 		formatter = formatters.Fallback
 	}

--- a/internal/ui/constants.go
+++ b/internal/ui/constants.go
@@ -66,3 +66,81 @@ const (
 	// ModalInputWidth is the width of modal text inputs
 	ModalInputWidth = 72
 )
+
+// Modal visibility limits - maximum items shown at once before scrolling
+const (
+	// HelpModalMaxVisible is the max visible lines in the help modal
+	HelpModalMaxVisible = 18
+
+	// IssuesModalMaxVisible is the max visible issues in the GitHub issues modal
+	IssuesModalMaxVisible = 10
+
+	// SearchModalMaxVisible is the max visible search results
+	SearchModalMaxVisible = 8
+
+	// ChangelogModalMaxVisible is the max visible lines in the changelog modal
+	ChangelogModalMaxVisible = 15
+
+	// PlanApprovalMaxVisible is the max visible lines in the plan approval prompt
+	PlanApprovalMaxVisible = 20
+)
+
+// Text input character limits for various inputs
+const (
+	// SidebarSearchCharLimit is the character limit for sidebar search
+	SidebarSearchCharLimit = 50
+
+	// BranchNameCharLimit is the character limit for branch name inputs
+	BranchNameCharLimit = 100
+
+	// SessionNameCharLimit is the character limit for session name inputs
+	SessionNameCharLimit = 100
+
+	// SearchInputCharLimit is the character limit for search filter inputs
+	SearchInputCharLimit = 100
+
+	// MCPServerNameCharLimit is the character limit for MCP server names
+	MCPServerNameCharLimit = 50
+
+	// MCPCommandCharLimit is the character limit for MCP server commands
+	MCPCommandCharLimit = 100
+
+	// MCPArgsCharLimit is the character limit for MCP server arguments
+	MCPArgsCharLimit = 200
+
+	// PluginSearchCharLimit is the character limit for plugin search
+	PluginSearchCharLimit = 50
+
+	// MarketplaceSourceCharLimit is the character limit for marketplace source URLs
+	MarketplaceSourceCharLimit = 200
+
+	// BranchPrefixCharLimit is the character limit for branch prefix settings
+	BranchPrefixCharLimit = 50
+)
+
+// Logging preview lengths
+const (
+	// PasteContentPreviewLen is the max length for paste content in logs
+	PasteContentPreviewLen = 100
+
+	// InputMessagePreviewLen is the max length for input message previews in logs
+	InputMessagePreviewLen = 50
+)
+
+// Syntax highlighting configuration
+const (
+	// DefaultSyntaxStyle is the default chroma style for syntax highlighting
+	DefaultSyntaxStyle = "monokai"
+
+	// DefaultTerminalFormatter is the default chroma formatter for terminal output
+	DefaultTerminalFormatter = "terminal256"
+)
+
+// Todo list rendering
+const (
+	// TodoListMinWrapWidth is the minimum wrap width for todo lists
+	TodoListMinWrapWidth = 20
+
+	// TodoListFallbackWrapWidth is the fallback wrap width when viewport not initialized
+	TodoListFallbackWrapWidth = 80
+)

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -186,9 +186,30 @@ func initModalStyles() {
 	)
 }
 
-// init ensures modal styles are initialized
+// initModalConstants initializes the modal constants in the modals package.
+// This should be called once at startup.
+func initModalConstants() {
+	modals.SetConstants(modals.ModalConstants{
+		HelpModalMaxVisible:        HelpModalMaxVisible,
+		IssuesModalMaxVisible:      IssuesModalMaxVisible,
+		SearchModalMaxVisible:      SearchModalMaxVisible,
+		ChangelogModalMaxVisible:   ChangelogModalMaxVisible,
+		BranchNameCharLimit:        BranchNameCharLimit,
+		SessionNameCharLimit:       SessionNameCharLimit,
+		SearchInputCharLimit:       SearchInputCharLimit,
+		MCPServerNameCharLimit:     MCPServerNameCharLimit,
+		MCPCommandCharLimit:        MCPCommandCharLimit,
+		MCPArgsCharLimit:           MCPArgsCharLimit,
+		PluginSearchCharLimit:      PluginSearchCharLimit,
+		MarketplaceSourceCharLimit: MarketplaceSourceCharLimit,
+		BranchPrefixCharLimit:      BranchPrefixCharLimit,
+	})
+}
+
+// init ensures modal styles and constants are initialized
 func init() {
 	initModalStyles()
+	initModalConstants()
 }
 
 // RefreshModalStyles refreshes the modal styles after a theme change.

--- a/internal/ui/modals/config.go
+++ b/internal/ui/modals/config.go
@@ -212,7 +212,7 @@ func NewChangelogState(entries []ChangelogEntry) *ChangelogState {
 	return &ChangelogState{
 		Entries:         entries,
 		ScrollOffset:    0,
-		maxVisibleLines: 15,
+		maxVisibleLines: ChangelogModalMaxVisible,
 	}
 }
 
@@ -430,7 +430,7 @@ func (s *SettingsState) GetNotificationsEnabled() bool {
 func NewSettingsState(currentBranchPrefix string, notificationsEnabled bool) *SettingsState {
 	prefixInput := textinput.New()
 	prefixInput.Placeholder = "e.g., zhubert/ (leave empty for no prefix)"
-	prefixInput.CharLimit = 50
+	prefixInput.CharLimit = BranchPrefixCharLimit
 	prefixInput.SetWidth(ModalInputWidth)
 	prefixInput.SetValue(currentBranchPrefix)
 	prefixInput.Focus()

--- a/internal/ui/modals/help.go
+++ b/internal/ui/modals/help.go
@@ -168,6 +168,6 @@ func NewHelpStateFromSections(sections []HelpSection) *HelpState {
 		FlatShortcuts: flatShortcuts,
 		ScrollOffset:  0,
 		SelectedIndex: 0,
-		maxVisible:    18,
+		maxVisible:    HelpModalMaxVisible,
 	}
 }

--- a/internal/ui/modals/issues.go
+++ b/internal/ui/modals/issues.go
@@ -206,6 +206,6 @@ func NewImportIssuesState(repoPath, repoName string) *ImportIssuesState {
 		Loading:       true,
 		SelectedIndex: 0,
 		ScrollOffset:  0,
-		maxVisible:    10,
+		maxVisible:    IssuesModalMaxVisible,
 	}
 }

--- a/internal/ui/modals/mcp.go
+++ b/internal/ui/modals/mcp.go
@@ -340,18 +340,18 @@ func (s *AddMCPServerState) GetValues() (name, command, args, repoPath string, i
 func NewAddMCPServerState(repos []string) *AddMCPServerState {
 	nameInput := textinput.New()
 	nameInput.Placeholder = "server-name"
-	nameInput.CharLimit = 50
+	nameInput.CharLimit = MCPServerNameCharLimit
 	nameInput.SetWidth(ModalInputWidth)
 	nameInput.Focus()
 
 	cmdInput := textinput.New()
 	cmdInput.Placeholder = "npx"
-	cmdInput.CharLimit = 100
+	cmdInput.CharLimit = MCPCommandCharLimit
 	cmdInput.SetWidth(ModalInputWidth)
 
 	argsInput := textinput.New()
 	argsInput.Placeholder = "@modelcontextprotocol/server-github"
-	argsInput.CharLimit = 200
+	argsInput.CharLimit = MCPArgsCharLimit
 	argsInput.SetWidth(ModalInputWidth)
 
 	return &AddMCPServerState{

--- a/internal/ui/modals/plugins.go
+++ b/internal/ui/modals/plugins.go
@@ -471,7 +471,7 @@ func (s *PluginsState) GetSelectedAvailablePlugin() *PluginDisplay {
 func NewPluginsState() *PluginsState {
 	searchInput := textinput.New()
 	searchInput.Placeholder = "filter plugins..."
-	searchInput.CharLimit = 50
+	searchInput.CharLimit = PluginSearchCharLimit
 	searchInput.SetWidth(30)
 	// Don't focus by default - Tab toggles focus
 
@@ -491,7 +491,7 @@ func NewPluginsState() *PluginsState {
 func NewPluginsStateWithData(marketplaces []MarketplaceDisplay, plugins []PluginDisplay) *PluginsState {
 	searchInput := textinput.New()
 	searchInput.Placeholder = "filter plugins..."
-	searchInput.CharLimit = 50
+	searchInput.CharLimit = PluginSearchCharLimit
 	searchInput.SetWidth(30)
 	// Don't focus by default - Tab toggles focus
 
@@ -573,7 +573,7 @@ func (s *AddMarketplaceState) GetValue() string {
 func NewAddMarketplaceState() *AddMarketplaceState {
 	sourceInput := textinput.New()
 	sourceInput.Placeholder = "owner/repo or https://..."
-	sourceInput.CharLimit = 200
+	sourceInput.CharLimit = MarketplaceSourceCharLimit
 	sourceInput.SetWidth(ModalInputWidth)
 	sourceInput.Focus()
 

--- a/internal/ui/modals/search.go
+++ b/internal/ui/modals/search.go
@@ -285,7 +285,7 @@ func (s *SearchMessagesState) GetSelectedResult() *SearchResult {
 func NewSearchMessagesState(messages []struct{ Role, Content string }) *SearchMessagesState {
 	input := textinput.New()
 	input.Placeholder = "Type to search..."
-	input.CharLimit = 100
+	input.CharLimit = SearchInputCharLimit
 	input.SetWidth(ModalInputWidth)
 	input.Focus()
 
@@ -302,6 +302,6 @@ func NewSearchMessagesState(messages []struct{ Role, Content string }) *SearchMe
 	return &SearchMessagesState{
 		Input:       input,
 		AllMessages: allMessages,
-		maxVisible:  8,
+		maxVisible:  SearchModalMaxVisible,
 	}
 }

--- a/internal/ui/modals/session.go
+++ b/internal/ui/modals/session.go
@@ -156,7 +156,7 @@ func (s *NewSessionState) GetBaseIndex() int {
 func NewNewSessionState(repos []string) *NewSessionState {
 	branchInput := textinput.New()
 	branchInput.Placeholder = "optional branch name (leave empty for auto)"
-	branchInput.CharLimit = 100
+	branchInput.CharLimit = BranchNameCharLimit
 	branchInput.SetWidth(ModalInputWidth)
 
 	return &NewSessionState{
@@ -313,7 +313,7 @@ func (s *ForkSessionState) ShouldCopyMessages() bool {
 func NewForkSessionState(parentSessionName, parentSessionID, repoPath string) *ForkSessionState {
 	branchInput := textinput.New()
 	branchInput.Placeholder = "optional branch name (leave empty for auto)"
-	branchInput.CharLimit = 100
+	branchInput.CharLimit = BranchNameCharLimit
 	branchInput.SetWidth(ModalInputWidth)
 
 	return &ForkSessionState{
@@ -398,7 +398,7 @@ func (s *RenameSessionState) GetNewName() string {
 func NewRenameSessionState(sessionID, currentName string) *RenameSessionState {
 	nameInput := textinput.New()
 	nameInput.Placeholder = "enter new name"
-	nameInput.CharLimit = 100
+	nameInput.CharLimit = SessionNameCharLimit
 	nameInput.SetWidth(ModalInputWidth)
 	nameInput.SetValue(currentName)
 	nameInput.Focus()

--- a/internal/ui/modals/styles.go
+++ b/internal/ui/modals/styles.go
@@ -28,6 +28,27 @@ var (
 	ModalWidth          int
 )
 
+// Modal visibility limits - maximum items shown at once before scrolling
+var (
+	HelpModalMaxVisible      int
+	IssuesModalMaxVisible    int
+	SearchModalMaxVisible    int
+	ChangelogModalMaxVisible int
+)
+
+// Text input character limits for various modal inputs
+var (
+	BranchNameCharLimit        int
+	SessionNameCharLimit       int
+	SearchInputCharLimit       int
+	MCPServerNameCharLimit     int
+	MCPCommandCharLimit        int
+	MCPArgsCharLimit           int
+	PluginSearchCharLimit      int
+	MarketplaceSourceCharLimit int
+	BranchPrefixCharLimit      int
+)
+
 // SetStyles sets the style variables from the parent ui package.
 // This must be called before rendering any modals.
 func SetStyles(
@@ -52,6 +73,45 @@ func SetStyles(
 	ModalInputWidth = inputWidth
 	ModalInputCharLimit = inputCharLimit
 	ModalWidth = modalWidth
+}
+
+// ModalConstants holds all the constant values needed by modals
+type ModalConstants struct {
+	// Visibility limits
+	HelpModalMaxVisible      int
+	IssuesModalMaxVisible    int
+	SearchModalMaxVisible    int
+	ChangelogModalMaxVisible int
+
+	// Text input character limits
+	BranchNameCharLimit        int
+	SessionNameCharLimit       int
+	SearchInputCharLimit       int
+	MCPServerNameCharLimit     int
+	MCPCommandCharLimit        int
+	MCPArgsCharLimit           int
+	PluginSearchCharLimit      int
+	MarketplaceSourceCharLimit int
+	BranchPrefixCharLimit      int
+}
+
+// SetConstants sets the constant values from the parent ui package.
+// This must be called before rendering any modals.
+func SetConstants(c ModalConstants) {
+	HelpModalMaxVisible = c.HelpModalMaxVisible
+	IssuesModalMaxVisible = c.IssuesModalMaxVisible
+	SearchModalMaxVisible = c.SearchModalMaxVisible
+	ChangelogModalMaxVisible = c.ChangelogModalMaxVisible
+
+	BranchNameCharLimit = c.BranchNameCharLimit
+	SessionNameCharLimit = c.SessionNameCharLimit
+	SearchInputCharLimit = c.SearchInputCharLimit
+	MCPServerNameCharLimit = c.MCPServerNameCharLimit
+	MCPCommandCharLimit = c.MCPCommandCharLimit
+	MCPArgsCharLimit = c.MCPArgsCharLimit
+	PluginSearchCharLimit = c.PluginSearchCharLimit
+	MarketplaceSourceCharLimit = c.MarketplaceSourceCharLimit
+	BranchPrefixCharLimit = c.BranchPrefixCharLimit
 }
 
 // ApplyTextareaStyles configures a textarea with transparent background styles.

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -68,7 +68,7 @@ type Sidebar struct {
 func NewSidebar() *Sidebar {
 	ti := textinput.New()
 	ti.Placeholder = "search..."
-	ti.CharLimit = 50
+	ti.CharLimit = SidebarSearchCharLimit
 
 	return &Sidebar{
 		selectedIdx:        0,


### PR DESCRIPTION
## Summary
Refactors hardcoded magic numbers throughout the codebase into named constants defined in `internal/ui/constants.go`, improving code readability and maintainability.

## Changes
- Add modal visibility limit constants (HelpModalMaxVisible, IssuesModalMaxVisible, etc.)
- Add text input character limit constants for various inputs (branch names, session names, search filters, MCP server fields, etc.)
- Add logging preview length constants (PasteContentPreviewLen, InputMessagePreviewLen)
- Add syntax highlighting configuration constants (DefaultSyntaxStyle, DefaultTerminalFormatter)
- Add todo list rendering constants (TodoListMinWrapWidth, TodoListFallbackWrapWidth)
- Add MaxBranchNameLength constant in git package for auto-generated branch names
- Add MaxBranchNameValidation constant in session package for user-provided branch names
- Create mechanism to pass constants from ui package to modals package via SetConstants()
- Update all usages throughout the codebase to reference the new constants

## Test plan
- Run `go test ./...` to verify all tests pass
- Verify the application builds successfully with `go build -o plural .`
- Manual testing: create sessions, fork sessions, use modals to confirm character limits and visibility settings work as expected