### PR TITLE
Simplify session state access with direct field access pattern

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -198,8 +198,11 @@ func (m *Model) CanSendMessage() bool {
 	}
 	// Check if the active session is currently waiting for a response or has a merge in progress
 	// Each session can operate independently
-	sm := m.sessionMgr.StateManager()
-	return !sm.IsWaiting(m.activeSession.ID) && !sm.IsMerging(m.activeSession.ID)
+	state := m.sessionMgr.StateManager().GetIfExists(m.activeSession.ID)
+	if state == nil {
+		return true // No state means not waiting or merging
+	}
+	return !state.IsWaiting && !state.IsMerging()
 }
 
 // setState transitions to a new state with logging
@@ -306,7 +309,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// Then check for streaming interruption
 			if m.activeSession != nil {
-				if cancel := m.sessionState().GetStreamCancel(m.activeSession.ID); cancel != nil {
+				if state := m.sessionState().GetIfExists(m.activeSession.ID); state != nil && state.StreamCancel != nil {
+					cancel := state.StreamCancel
 					logger.Log("App: Interrupting streaming for session %s", m.activeSession.ID)
 					cancel()
 					// Send SIGINT to interrupt the Claude process (handles sub-agent work)
@@ -339,15 +343,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			key := msg.String()
 
 			// Permission response
-			if req := m.sessionState().GetPendingPermission(m.activeSession.ID); req != nil {
+			state := m.sessionState().GetIfExists(m.activeSession.ID)
+			if state != nil && state.PendingPermission != nil {
+				req := state.PendingPermission
 				switch key {
 				case "y", "Y", "n", "N", "a", "A":
 					return m.handlePermissionResponse(key, m.activeSession.ID, req)
 				}
 			}
 
-			// Question response
-			if m.sessionState().GetPendingQuestion(m.activeSession.ID) != nil {
+			// Question response (reuse state from permission check)
+			if state != nil && state.PendingQuestion != nil {
 				switch key {
 				case "1", "2", "3", "4", "5":
 					num := int(key[0] - '0')
@@ -369,8 +375,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-			// Plan approval response
-			if m.sessionState().GetPendingPlanApproval(m.activeSession.ID) != nil {
+			// Plan approval response (reuse state from permission check)
+			if state != nil && state.PendingPlanApproval != nil {
 				switch key {
 				case "y", "Y":
 					return m.submitPlanApprovalResponse(m.activeSession.ID, true)
@@ -390,8 +396,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.handleImagePaste()
 			}
 
-			// Ctrl+P for parallel option exploration
-			if key == "ctrl+p" && m.sessionState().HasDetectedOptions(m.activeSession.ID) {
+			// Ctrl+P for parallel option exploration (reuse state from permission check)
+			if key == "ctrl+p" && state != nil && state.HasDetectedOptions() {
 				return m.showExploreOptionsModal()
 			}
 
@@ -425,7 +431,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.selectSession(sess)
 					// Check if this session has an unsent initial message (from issue import)
 					if initialMsg := m.sessionState().GetInitialMessage(sess.ID); initialMsg != "" {
-						m.sessionState().SetPendingMessage(sess.ID, initialMsg)
+						m.sessionState().GetOrCreate(sess.ID).PendingMessage = initialMsg
 						return m, func() tea.Msg {
 							return SendPendingMessageMsg{SessionID: sess.ID}
 						}
@@ -436,14 +442,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.CanSendMessage() {
 					// Send message immediately
 					return m.sendMessage()
-				} else if m.activeSession != nil && m.sessionState().IsWaiting(m.activeSession.ID) {
-					// Queue message to be sent when streaming completes
-					input := m.chat.GetInput()
-					if input != "" {
-						m.sessionState().SetPendingMessage(m.activeSession.ID, input)
-						m.chat.ClearInput()
-						m.chat.SetQueuedMessage(input)
-						logger.Log("App: Queued message for session %s while streaming", m.activeSession.ID)
+				} else if m.activeSession != nil {
+					// Check if waiting and queue message to be sent when streaming completes
+					sessState := m.sessionState().GetIfExists(m.activeSession.ID)
+					if sessState != nil && sessState.IsWaiting {
+						input := m.chat.GetInput()
+						if input != "" {
+							sessState.PendingMessage = input
+							m.chat.ClearInput()
+							m.chat.SetQueuedMessage(input)
+							logger.Log("App: Queued message for session %s while streaming", m.activeSession.ID)
+						}
 					}
 				}
 			}
@@ -943,7 +952,8 @@ func (m *Model) selectSession(sess *config.Session) {
 	}
 
 	// Restore queued message display if this session has a pending message
-	if pendingMsg := m.sessionState().PeekPendingMessage(sess.ID); pendingMsg != "" {
+	if state := m.sessionState().GetIfExists(sess.ID); state != nil && state.PendingMessage != "" {
+		pendingMsg := state.PendingMessage
 		m.chat.SetQueuedMessage(pendingMsg)
 	} else {
 		m.chat.ClearQueuedMessage()
@@ -1129,7 +1139,9 @@ func (m *Model) handlePermissionResponse(key string, sessionID string, req *mcp.
 	runner.SendPermissionResponse(resp)
 
 	// Clear pending permission
-	m.sessionState().ClearPendingPermission(sessionID)
+	if state := m.sessionState().GetIfExists(sessionID); state != nil {
+		state.PendingPermission = nil
+	}
 	m.sidebar.SetPendingPermission(sessionID, false)
 	m.chat.ClearPendingPermission()
 
@@ -1222,11 +1234,12 @@ func (m *Model) submitQuestionResponse(sessionID string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	req := m.sessionState().GetPendingQuestion(sessionID)
-	if req == nil {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingQuestion == nil {
 		logger.Log("App: No pending question for session %s", sessionID)
 		return m, nil
 	}
+	req := state.PendingQuestion
 
 	// Get answers from chat
 	answers := m.chat.GetQuestionAnswers()
@@ -1242,7 +1255,7 @@ func (m *Model) submitQuestionResponse(sessionID string) (tea.Model, tea.Cmd) {
 	runner.SendQuestionResponse(resp)
 
 	// Clear pending question
-	m.sessionState().ClearPendingQuestion(sessionID)
+	state.PendingQuestion = nil
 	m.sidebar.SetPendingPermission(sessionID, false)
 	m.chat.ClearPendingQuestion()
 
@@ -1278,11 +1291,12 @@ func (m *Model) submitPlanApprovalResponse(sessionID string, approved bool) (tea
 		return m, nil
 	}
 
-	req := m.sessionState().GetPendingPlanApproval(sessionID)
-	if req == nil {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingPlanApproval == nil {
 		logger.Log("App: No pending plan approval for session %s", sessionID)
 		return m, nil
 	}
+	req := state.PendingPlanApproval
 
 	logger.Log("App: Plan approval response for session %s: approved=%v", sessionID, approved)
 
@@ -1296,7 +1310,7 @@ func (m *Model) submitPlanApprovalResponse(sessionID string, approved bool) (tea
 	runner.SendPlanApprovalResponse(resp)
 
 	// Clear pending plan approval
-	m.sessionState().ClearPendingPlanApproval(sessionID)
+	state.PendingPlanApproval = nil
 	m.sidebar.SetPendingPermission(sessionID, false)
 	m.chat.ClearPendingPlanApproval()
 
@@ -1305,10 +1319,11 @@ func (m *Model) submitPlanApprovalResponse(sessionID string, approved bool) (tea
 }
 
 func (m *Model) listenForMergeResult(sessionID string) tea.Cmd {
-	ch := m.sessionState().GetMergeChan(sessionID)
-	if ch == nil {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.MergeChan == nil {
 		return nil
 	}
+	ch := state.MergeChan
 
 	return func() tea.Msg {
 		result, ok := <-ch
@@ -1383,9 +1398,10 @@ func (m *Model) HasActiveStreaming() bool {
 
 // detectOptionsInSession scans the runner's messages for numbered options
 func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInterface) {
+	state := m.sessionState().GetOrCreate(sessionID)
 	msgs := runner.GetMessages()
 	if len(msgs) == 0 {
-		m.sessionState().ClearDetectedOptions(sessionID)
+		state.DetectedOptions = nil
 		return
 	}
 
@@ -1395,7 +1411,7 @@ func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInt
 			options := DetectOptions(msgs[i].Content)
 			if len(options) >= 2 {
 				logger.Log("App: Detected %d options in session %s", len(options), sessionID)
-				m.sessionState().SetDetectedOptions(sessionID, options)
+				state.DetectedOptions = options
 				return
 			}
 			break // Only check the most recent assistant message
@@ -1403,7 +1419,7 @@ func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInt
 	}
 
 	// No options found
-	m.sessionState().ClearDetectedOptions(sessionID)
+	state.DetectedOptions = nil
 }
 
 // showExploreOptionsModal displays the modal for selecting options to explore in parallel
@@ -1412,10 +1428,11 @@ func (m *Model) showExploreOptionsModal() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	options := m.sessionState().GetDetectedOptions(m.activeSession.ID)
-	if len(options) < 2 {
+	state := m.sessionState().GetIfExists(m.activeSession.ID)
+	if state == nil || !state.HasDetectedOptions() {
 		return m, nil
 	}
+	options := state.DetectedOptions
 
 	// Convert to UI option items
 	items := make([]ui.OptionItem, len(options))
@@ -1561,12 +1578,17 @@ func (m *Model) View() tea.View {
 	// Update footer context for conditional bindings
 	hasSession := m.sidebar.SelectedSession() != nil
 	sidebarFocused := m.focus == FocusSidebar
-	hasPendingPermission := m.activeSession != nil && m.sessionState().GetPendingPermission(m.activeSession.ID) != nil
-	hasPendingQuestion := m.activeSession != nil && m.sessionState().GetPendingQuestion(m.activeSession.ID) != nil
-	isStreaming := m.activeSession != nil && m.sessionState().GetStreamCancel(m.activeSession.ID) != nil
+	var hasPendingPermission, hasPendingQuestion, isStreaming, hasDetectedOptions bool
+	if m.activeSession != nil {
+		if state := m.sessionState().GetIfExists(m.activeSession.ID); state != nil {
+			hasPendingPermission = state.PendingPermission != nil
+			hasPendingQuestion = state.PendingQuestion != nil
+			isStreaming = state.StreamCancel != nil
+			hasDetectedOptions = state.HasDetectedOptions()
+		}
+	}
 	viewChangesMode := m.chat.IsInViewChangesMode()
 	searchMode := m.sidebar.IsSearchMode()
-	hasDetectedOptions := m.activeSession != nil && m.sessionState().HasDetectedOptions(m.activeSession.ID)
 	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, hasDetectedOptions)
 
 	header := m.header.View()
@@ -1641,12 +1663,17 @@ func (m *Model) RenderToString() string {
 	// Update footer context for conditional bindings
 	hasSession := m.sidebar.SelectedSession() != nil
 	sidebarFocused := m.focus == FocusSidebar
-	hasPendingPermission := m.activeSession != nil && m.sessionState().GetPendingPermission(m.activeSession.ID) != nil
-	hasPendingQuestion := m.activeSession != nil && m.sessionState().GetPendingQuestion(m.activeSession.ID) != nil
-	isStreaming := m.activeSession != nil && m.sessionState().GetStreamCancel(m.activeSession.ID) != nil
+	var hasPendingPermission, hasPendingQuestion, isStreaming, hasDetectedOptions bool
+	if m.activeSession != nil {
+		if state := m.sessionState().GetIfExists(m.activeSession.ID); state != nil {
+			hasPendingPermission = state.PendingPermission != nil
+			hasPendingQuestion = state.PendingQuestion != nil
+			isStreaming = state.StreamCancel != nil
+			hasDetectedOptions = state.HasDetectedOptions()
+		}
+	}
 	viewChangesMode := m.chat.IsInViewChangesMode()
 	searchMode := m.sidebar.IsSearchMode()
-	hasDetectedOptions := m.activeSession != nil && m.sessionState().HasDetectedOptions(m.activeSession.ID)
 	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, hasDetectedOptions)
 
 	header := m.header.View()

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -138,8 +138,8 @@ func TestPermission_FullFlow_Approve(t *testing.T) {
 		t.Error("Chat should have pending permission")
 	}
 
-	pending := m.sessionState().GetPendingPermission(sessionID)
-	if pending == nil || pending.Tool != "Bash" {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingPermission == nil || state.PendingPermission.Tool != "Bash" {
 		t.Error("Session state should have pending Bash permission")
 	}
 
@@ -150,7 +150,8 @@ func TestPermission_FullFlow_Approve(t *testing.T) {
 	if m.chat.HasPendingPermission() {
 		t.Error("Permission should be cleared after approval")
 	}
-	if m.sessionState().GetPendingPermission(sessionID) != nil {
+	state = m.sessionState().GetIfExists(sessionID)
+	if state != nil && state.PendingPermission != nil {
 		t.Error("Session state permission should be cleared")
 	}
 }
@@ -228,7 +229,8 @@ func TestPermission_OnlyInChatFocus(t *testing.T) {
 	m = sendKey(m, "y")
 
 	// Permission should still be pending
-	if m.sessionState().GetPendingPermission(sessionID) == nil {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingPermission == nil {
 		t.Error("Permission should still be pending when response sent from sidebar")
 	}
 }
@@ -469,7 +471,8 @@ func TestSessionSwitch_PreservesPendingPermission(t *testing.T) {
 	}
 
 	// But session A's state should still have it
-	if m.sessionState().GetPendingPermission(sessionA) == nil {
+	stateA := m.sessionState().GetIfExists(sessionA)
+	if stateA == nil || stateA.PendingPermission == nil {
 		t.Error("Session A should still have pending permission in state")
 	}
 
@@ -515,7 +518,8 @@ func TestSessionSwitch_PreservesPendingQuestion(t *testing.T) {
 	m = sendKey(m, "enter")
 
 	// Session A state should still have question
-	if m.sessionState().GetPendingQuestion(sessionA) == nil {
+	stateA := m.sessionState().GetIfExists(sessionA)
+	if stateA == nil || stateA.PendingQuestion == nil {
 		t.Error("Session A should still have pending question in state")
 	}
 
@@ -607,16 +611,16 @@ func TestMessageQueue_DuringStreaming(t *testing.T) {
 	m.setState(StateStreamingClaude)
 
 	// Queue a pending message
-	m.sessionState().SetPendingMessage(sessionID, "queued message")
+	m.sessionState().GetOrCreate(sessionID).PendingMessage = "queued message"
 
 	// Verify message is queued
-	if !m.sessionState().HasPendingMessage(sessionID) {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingMessage == "" {
 		t.Error("Message should be queued during streaming")
 	}
 
-	queued := m.sessionState().PeekPendingMessage(sessionID)
-	if queued != "queued message" {
-		t.Errorf("Expected 'queued message', got %q", queued)
+	if state.PendingMessage != "queued message" {
+		t.Errorf("Expected 'queued message', got %q", state.PendingMessage)
 	}
 }
 

--- a/internal/app/modal_handlers_git.go
+++ b/internal/app/modal_handlers_git.go
@@ -26,7 +26,7 @@ func (m *Model) handleMergeModal(key string, msg tea.KeyPressMsg, state *ui.Merg
 			return m, nil
 		}
 		// Check if this session already has a merge in progress
-		if m.sessionState().IsMerging(sess.ID) {
+		if state := m.sessionState().GetIfExists(sess.ID); state != nil && state.IsMerging() {
 			logger.Log("App: Merge already in progress for session %s", sess.ID)
 			return m, nil
 		}

--- a/internal/app/modal_handlers_github.go
+++ b/internal/app/modal_handlers_github.go
@@ -308,7 +308,9 @@ func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Mod
 	m.sidebar.SetSessions(m.config.GetSessions())
 
 	// Clear detected options since we've acted on them
-	m.sessionState().ClearDetectedOptions(parentSession.ID)
+	if state := m.sessionState().GetIfExists(parentSession.ID); state != nil {
+		state.DetectedOptions = nil
+	}
 
 	// Start all sessions in parallel
 	if len(createdSessions) > 0 {

--- a/internal/app/modal_integration_test.go
+++ b/internal/app/modal_integration_test.go
@@ -1454,7 +1454,7 @@ func TestModalDoesNotAffectSessionState(t *testing.T) {
 	sessionID := m.activeSession.ID
 
 	// Add some state
-	m.sessionState().SetPendingMessage(sessionID, "pending message")
+	m.sessionState().GetOrCreate(sessionID).PendingMessage = "pending message"
 
 	// Open and close various modals
 	m = sendKey(m, "tab") // Back to sidebar
@@ -1466,13 +1466,13 @@ func TestModalDoesNotAffectSessionState(t *testing.T) {
 	m = sendKey(m, "esc")
 
 	// Session state should be preserved
-	if !m.sessionState().HasPendingMessage(sessionID) {
+	state := m.sessionState().GetIfExists(sessionID)
+	if state == nil || state.PendingMessage == "" {
 		t.Error("Session state should be preserved after opening/closing modals")
 	}
 
-	pending := m.sessionState().PeekPendingMessage(sessionID)
-	if pending != "pending message" {
-		t.Errorf("Expected pending message 'pending message', got %q", pending)
+	if state.PendingMessage != "pending message" {
+		t.Errorf("Expected pending message 'pending message', got %q", state.PendingMessage)
 	}
 }
 

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -176,14 +176,16 @@ func TestSessionManager_Select_SavesPreviousState(t *testing.T) {
 	sm.Select(sess, "prev-session", "saved input", "saved streaming")
 
 	// Verify state was saved
-	savedInput := sm.stateManager.GetInput("prev-session")
-	if savedInput != "saved input" {
-		t.Errorf("Expected saved input 'saved input', got %q", savedInput)
+	state := sm.stateManager.GetIfExists("prev-session")
+	if state == nil {
+		t.Fatal("Expected state for prev-session")
+	}
+	if state.InputText != "saved input" {
+		t.Errorf("Expected saved input 'saved input', got %q", state.InputText)
 	}
 
-	savedStreaming := sm.stateManager.GetStreaming("prev-session")
-	if savedStreaming != "saved streaming" {
-		t.Errorf("Expected saved streaming 'saved streaming', got %q", savedStreaming)
+	if state.StreamingContent != "saved streaming" {
+		t.Errorf("Expected saved streaming 'saved streaming', got %q", state.StreamingContent)
 	}
 }
 
@@ -255,9 +257,10 @@ func TestSessionManager_Select_RestoresState(t *testing.T) {
 	// Set up state to restore
 	sm.stateManager.StartWaiting(sess.ID, nil)
 	permReq := &mcp.PermissionRequest{Tool: "Bash", Description: "test"}
-	sm.stateManager.SetPendingPermission(sess.ID, permReq)
-	sm.stateManager.SaveStreaming(sess.ID, "streaming content")
-	sm.stateManager.SaveInput(sess.ID, "saved input text")
+	state := sm.stateManager.GetOrCreate(sess.ID)
+	state.PendingPermission = permReq
+	state.StreamingContent = "streaming content"
+	state.InputText = "saved input text"
 
 	result := sm.Select(sess, "", "", "")
 
@@ -285,7 +288,7 @@ func TestSessionManager_DeleteSession(t *testing.T) {
 	// Create runner and state
 	runner := claude.New("session-1", "/test", false, nil)
 	sm.runners["session-1"] = runner
-	sm.stateManager.SaveInput("session-1", "test input")
+	sm.stateManager.GetOrCreate("session-1").InputText = "test input"
 
 	// Delete session
 	deletedRunner := sm.DeleteSession("session-1")
@@ -300,7 +303,8 @@ func TestSessionManager_DeleteSession(t *testing.T) {
 	}
 
 	// State should be cleaned up
-	if sm.stateManager.GetInput("session-1") != "" {
+	state := sm.stateManager.GetIfExists("session-1")
+	if state != nil {
 		t.Error("State should be cleaned up after delete")
 	}
 }

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -461,7 +461,8 @@ func shortcutViewChanges(m *Model) (tea.Model, tea.Cmd) {
 func shortcutMerge(m *Model) (tea.Model, tea.Cmd) {
 	sess := m.sidebar.SelectedSession()
 	// Don't show merge modal if already merging or generating commit message
-	if m.sessionState().IsMerging(sess.ID) || m.pendingCommitSession == sess.ID {
+	state := m.sessionState().GetIfExists(sess.ID)
+	if (state != nil && state.IsMerging()) || m.pendingCommitSession == sess.ID {
 		return m, nil
 	}
 	hasRemote := git.HasRemoteOrigin(sess.RepoPath)


### PR DESCRIPTION
## Summary
Refactors the session state management API to use direct field access instead of individual getter/setter methods, reducing boilerplate and improving code clarity.

## Changes
- Add `GetOrCreate()` and `GetIfExists()` methods to `SessionStateManager` for direct state access
- Add helper methods to `SessionState` struct: `HasDetectedOptions()`, `HasTodoList()`, `IsMerging()`
- Remove 30+ individual getter/setter methods that are now replaced by direct field access
- Update all call sites in `app.go`, `msg_handlers.go`, `modal_handlers_*.go`, and `session_manager.go`
- Keep methods with special semantics: `StartWaiting`, `StopWaiting`, `StartMerge`, `StopMerge`, `GetPendingMessage` (consuming get), `GetInitialMessage` (consuming get), `ReplaceToolUseMarker`
- Update tests to use new access pattern

## Test plan
- Run `go test ./...` to verify all tests pass
- Verify session state operations work correctly:
  - Permission requests are stored and cleared properly
  - Streaming content is tracked for non-active sessions
  - Message queueing during streaming works
  - Merge operations track state correctly