### PR TITLE
Add sync.Once to prevent double-close panic on response channel

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1093,6 +1094,7 @@ func TestHandleFatalError(t *testing.T) {
 	ch := make(chan ResponseChunk, 10)
 	runner.mu.Lock()
 	runner.currentResponseCh = ch
+	runner.closeResponseChOnce = &sync.Once{} // Required for closeResponseChannel to work
 	runner.mu.Unlock()
 
 	// Call handleFatalError


### PR DESCRIPTION
## Summary
Fixes a race condition where multiple code paths could attempt to close the response channel simultaneously, causing a panic.

## Changes
- Add `closeResponseChOnce *sync.Once` field to Runner struct to ensure the response channel is closed exactly once per Send operation
- Create `closeResponseChannel()` helper method that uses sync.Once to safely close the channel
- Replace all direct `close(ch)` calls with `closeResponseChannel()` in `handleProcessLine`, `handleProcessExit`, and `handleFatalError`
- Initialize a fresh `sync.Once` instance in `SendContent` for each new response channel
- Update test to initialize `closeResponseChOnce` field

## Test plan
- Run `go test ./internal/claude/...` to verify existing tests pass
- The fix prevents panics when `handleProcessLine`, `handleProcessExit`, and `handleFatalError` race to close the same channel (e.g., during process termination while a response is completing)