### PR TITLE
Add mutex to SessionState for thread-safe field access

### DIFF
--- a/internal/app/session_state_test.go
+++ b/internal/app/session_state_test.go
@@ -293,20 +293,20 @@ func TestSessionStateManager_ConcurrentAccess(t *testing.T) {
 					m.GetOrCreate(sessionID)
 				case 1:
 					state := m.GetOrCreate(sessionID)
-					state.PendingPermission = &mcp.PermissionRequest{ID: "perm"}
-					state.PendingPermission = nil
+					state.SetPendingPermission(&mcp.PermissionRequest{ID: "perm"})
+					state.SetPendingPermission(nil)
 				case 2:
 					state := m.GetOrCreate(sessionID)
-					state.InputText = "input"
-					_ = state.InputText
+					state.SetInputText("input")
+					_ = state.GetInputText()
 				case 3:
 					state := m.GetOrCreate(sessionID)
-					state.StreamingContent += "chunk"
-					_ = state.StreamingContent
+					state.AppendStreamingContent("chunk")
+					_ = state.GetStreamingContent()
 				case 4:
 					state := m.GetIfExists(sessionID)
 					if state != nil {
-						_ = state.IsWaiting
+						_ = state.GetIsWaiting()
 					}
 				case 5:
 					state := m.GetIfExists(sessionID)


### PR DESCRIPTION
## Summary
Adds an internal mutex to `SessionState` to protect concurrent access to its fields. Previously, while `SessionStateManager` had a mutex protecting the map of sessions, individual `SessionState` fields could be accessed concurrently without synchronization, leading to potential race conditions.

## Changes
- Add `sync.Mutex` to `SessionState` struct for per-state locking
- Add thread-safe getter/setter methods for all `SessionState` fields (e.g., `GetStreamingContent`, `SetPendingPermission`, `AppendStreamingContent`)
- Add `WithLock()` method for operations that need to access multiple fields atomically
- Update all call sites in `app.go`, `msg_handlers.go`, and `session_manager.go` to use the new thread-safe accessors
- Refactor `SessionStateManager` methods to use read locks where possible and delegate field locking to `SessionState`
- Update tests to use the new thread-safe methods

## Test plan
- Run `go test ./...` to verify all existing tests pass
- The concurrent access test in `session_state_test.go` validates thread safety
- Manual testing: run Plural with multiple sessions streaming simultaneously to verify no race conditions