### PR TITLE
Refactor git and session packages to use service pattern

### DIFF
--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zhubert/plural/internal/claude"
 	"github.com/zhubert/plural/internal/config"
+	"github.com/zhubert/plural/internal/git"
 	"github.com/zhubert/plural/internal/mcp"
 )
 
@@ -42,7 +43,7 @@ func createTestConfig() *config.Config {
 
 func TestNewSessionManager(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	if sm == nil {
 		t.Fatal("NewSessionManager returned nil")
@@ -63,7 +64,7 @@ func TestNewSessionManager(t *testing.T) {
 
 func TestSessionManager_StateManager(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	stateManager := sm.StateManager()
 	if stateManager == nil {
@@ -77,7 +78,7 @@ func TestSessionManager_StateManager(t *testing.T) {
 
 func TestSessionManager_GetRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// No runner initially
 	runner := sm.GetRunner("session-1")
@@ -97,7 +98,7 @@ func TestSessionManager_GetRunner(t *testing.T) {
 
 func TestSessionManager_GetRunners(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	runners := sm.GetRunners()
 	if runners == nil {
@@ -120,7 +121,7 @@ func TestSessionManager_GetRunners(t *testing.T) {
 
 func TestSessionManager_HasActiveStreaming(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// No runners - no streaming
 	if sm.HasActiveStreaming() {
@@ -141,7 +142,7 @@ func TestSessionManager_HasActiveStreaming(t *testing.T) {
 
 func TestSessionManager_GetSession(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Get existing session
 	sess := sm.GetSession("session-1")
@@ -162,7 +163,7 @@ func TestSessionManager_GetSession(t *testing.T) {
 
 func TestSessionManager_Select_Nil(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	result := sm.Select(nil, "", "", "")
 	if result != nil {
@@ -172,7 +173,7 @@ func TestSessionManager_Select_Nil(t *testing.T) {
 
 func TestSessionManager_Select_SavesPreviousState(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Select a session with previous state to save
 	sess := sm.GetSession("session-1")
@@ -194,7 +195,7 @@ func TestSessionManager_Select_SavesPreviousState(t *testing.T) {
 
 func TestSessionManager_Select_CreatesRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sess := sm.GetSession("session-1")
 	result := sm.Select(sess, "", "", "")
@@ -216,7 +217,7 @@ func TestSessionManager_Select_CreatesRunner(t *testing.T) {
 
 func TestSessionManager_Select_ReusesRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Pre-create a runner
 	existingRunner := claude.New("session-1", "/test", false, nil)
@@ -232,7 +233,7 @@ func TestSessionManager_Select_ReusesRunner(t *testing.T) {
 
 func TestSessionManager_Select_HeaderName(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Session with auto-generated branch (plural-)
 	sess := sm.GetSession("session-1")
@@ -253,7 +254,7 @@ func TestSessionManager_Select_HeaderName(t *testing.T) {
 
 func TestSessionManager_Select_RestoresState(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sess := sm.GetSession("session-1")
 
@@ -286,7 +287,7 @@ func TestSessionManager_Select_RestoresState(t *testing.T) {
 
 func TestSessionManager_DeleteSession(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Create runner and state
 	runner := claude.New("session-1", "/test", false, nil)
@@ -314,7 +315,7 @@ func TestSessionManager_DeleteSession(t *testing.T) {
 
 func TestSessionManager_DeleteSession_NoRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Delete session with no runner
 	deletedRunner := sm.DeleteSession("session-1")
@@ -326,7 +327,7 @@ func TestSessionManager_DeleteSession_NoRunner(t *testing.T) {
 
 func TestSessionManager_SetRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	runner := claude.New("session-1", "/test", false, nil)
 	sm.SetRunner("session-1", runner)
@@ -338,7 +339,7 @@ func TestSessionManager_SetRunner(t *testing.T) {
 
 func TestSessionManager_AddAllowedTool(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Create runner first
 	runner := claude.New("session-1", "/test", false, nil)
@@ -363,7 +364,7 @@ func TestSessionManager_AddAllowedTool(t *testing.T) {
 
 func TestSessionManager_AddAllowedTool_NoSession(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Should not panic with non-existent session
 	sm.AddAllowedTool("nonexistent", "Bash(git:*)")
@@ -371,7 +372,7 @@ func TestSessionManager_AddAllowedTool_NoSession(t *testing.T) {
 
 func TestSessionManager_AddAllowedTool_NoRunner(t *testing.T) {
 	cfg := createTestConfig()
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	// Should not panic when session exists but runner doesn't
 	sm.AddAllowedTool("session-1", "Bash(git:*)")
@@ -440,7 +441,7 @@ func TestSessionManager_Select_ForkedSession(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)
@@ -490,7 +491,7 @@ func TestSessionManager_Select_ForkedSession_AlreadyStarted(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)
@@ -526,7 +527,7 @@ func TestSessionManager_Select_NonForkedSession(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)
@@ -571,7 +572,7 @@ func TestSessionManager_Select_ForkedSession_ParentNotStarted(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)
@@ -608,7 +609,7 @@ func TestSessionManager_Select_ForkedSession_ParentNotFound(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)
@@ -718,7 +719,7 @@ func TestCopyClaudeSessionForFork_NoSessionFileCopyFallback(t *testing.T) {
 			},
 		},
 	}
-	sm := NewSessionManager(cfg)
+	sm := NewSessionManager(cfg, git.NewGitService())
 
 	sm.SetRunnerFactory(func(sessionID, workingDir string, sessionStarted bool, initialMessages []claude.Message) claude.RunnerInterface {
 		return newTrackingMockRunner(sessionID, sessionStarted, initialMessages)

--- a/internal/git/service.go
+++ b/internal/git/service.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	pexec "github.com/zhubert/plural/internal/exec"
+)
+
+// GitService provides git operations with explicit dependency injection.
+// Instead of using a package-level executor variable, each GitService instance
+// holds its own executor, enabling proper testing and avoiding global state.
+type GitService struct {
+	executor pexec.CommandExecutor
+}
+
+// NewGitService creates a new GitService with the default real executor.
+func NewGitService() *GitService {
+	return &GitService{executor: pexec.NewRealExecutor()}
+}
+
+// NewGitServiceWithExecutor creates a new GitService with a custom executor.
+// This is primarily used for testing and demo generation where a mock
+// executor is needed.
+func NewGitServiceWithExecutor(exec pexec.CommandExecutor) *GitService {
+	return &GitService{executor: exec}
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -1,0 +1,24 @@
+package session
+
+import (
+	pexec "github.com/zhubert/plural/internal/exec"
+)
+
+// SessionService provides session operations with explicit dependency injection.
+// Instead of using a package-level executor variable, each SessionService instance
+// holds its own executor, enabling proper testing and avoiding global state.
+type SessionService struct {
+	executor pexec.CommandExecutor
+}
+
+// NewSessionService creates a new SessionService with the default real executor.
+func NewSessionService() *SessionService {
+	return &SessionService{executor: pexec.NewRealExecutor()}
+}
+
+// NewSessionServiceWithExecutor creates a new SessionService with a custom executor.
+// This is primarily used for testing and demo generation where a mock
+// executor is needed.
+func NewSessionServiceWithExecutor(exec pexec.CommandExecutor) *SessionService {
+	return &SessionService{executor: exec}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -181,7 +182,9 @@ For more information, visit: https://github.com/zhubert/plural
 			}
 		}
 
-		prunedWorktrees, err := session.PruneOrphanedWorktrees(cfg)
+		sessionSvc := session.NewSessionService()
+		ctx := context.Background()
+		prunedWorktrees, err := sessionSvc.PruneOrphanedWorktrees(ctx, cfg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error pruning worktrees: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary
Refactors the `internal/git` and `internal/session` packages from using package-level global executors to a service struct pattern with explicit dependency injection. This improves testability and follows better Go practices for managing dependencies.

## Changes
- Add `GitService` struct (`internal/git/service.go`) that holds the command executor as an instance field
- Add `SessionService` struct (`internal/session/service.go`) with the same pattern
- Convert all git and session functions to methods on their respective service structs
- Add `context.Context` as first parameter to all I/O operations for proper cancellation/timeout support
- Inject services into `app.Model` and `SessionManager` via constructor
- Add `NewGitServiceWithExecutor()` and `NewSessionServiceWithExecutor()` constructors for testing/demos
- Update demo executor to use service injection instead of global executor swapping
- Update all call sites to use the injected services with context
- Update CLAUDE.md documentation with new service pattern details
- Update all tests to create services with the new constructors

## Test plan
- Run `go test ./...` to verify all existing tests pass
- Run `go build -o plural .` to verify the build succeeds
- Run `./plural` and test session creation, git operations (merge, PR, view changes), and forking to verify runtime behavior
- Run `plural demo run basic` to verify demo generation still works with the new service injection