### PR TITLE
Replace printf-style logging with structured slog calls

### DIFF
--- a/internal/app/modal_handlers_config.go
+++ b/internal/app/modal_handlers_config.go
@@ -27,7 +27,7 @@ func (m *Model) handleMCPServersModal(key string, msg tea.KeyPressMsg, state *ui
 				m.config.RemoveRepoMCPServer(server.RepoPath, server.Name)
 			}
 			if err := m.config.Save(); err != nil {
-				logger.Log("App: Failed to save config after MCP server deletion: %v", err)
+				logger.Get().Error("failed to save config after MCP server deletion", "error", err)
 				m.modal.Hide()
 				return m, m.ShowFlashError("Failed to save configuration")
 			}
@@ -68,7 +68,7 @@ func (m *Model) handleAddMCPServerModal(key string, msg tea.KeyPressMsg, state *
 			m.config.AddRepoMCPServer(repoPath, server)
 		}
 		if err := m.config.Save(); err != nil {
-			logger.Log("App: Failed to save MCP server config: %v", err)
+			logger.Get().Error("failed to save MCP server config", "error", err)
 			m.modal.Hide()
 			return m, m.ShowFlashError("Failed to save MCP server configuration")
 		}
@@ -232,7 +232,7 @@ func (m *Model) handleSettingsModal(key string, msg tea.KeyPressMsg, state *ui.S
 		m.config.SetDefaultBranchPrefix(branchPrefix)
 		m.config.SetNotificationsEnabled(state.GetNotificationsEnabled())
 		if err := m.config.Save(); err != nil {
-			logger.Log("App: Failed to save settings: %v", err)
+			logger.Get().Error("failed to save settings", "error", err)
 			m.modal.SetError("Failed to save: " + err.Error())
 			return m, nil
 		}

--- a/internal/app/modal_handlers_navigation.go
+++ b/internal/app/modal_handlers_navigation.go
@@ -113,7 +113,7 @@ func (m *Model) handleSearchMessagesModal(key string, msg tea.KeyPressMsg, state
 			m.modal.Hide()
 			// Scroll to message - for now we just close the modal
 			// Future enhancement: could scroll the chat viewport to the message
-			logger.Log("App: Search - selected message %d (%s)", result.MessageIndex+1, result.Role)
+			logger.Get().Debug("search - selected message", "index", result.MessageIndex+1, "role", result.Role)
 		}
 		return m, nil
 	}

--- a/internal/app/slash_commands.go
+++ b/internal/app/slash_commands.go
@@ -70,7 +70,7 @@ func (m *Model) handleSlashCommand(input string) SlashCommandResult {
 		args = parts[1]
 	}
 
-	logger.Log("App: Slash command detected: /%s args=%q", cmdName, args)
+	logger.Get().Debug("slash command detected", "command", cmdName, "args", args)
 
 	// Dispatch to the appropriate handler
 	switch cmdName {
@@ -84,7 +84,7 @@ func (m *Model) handleSlashCommand(input string) SlashCommandResult {
 		return handlePluginsCommand(m, args)
 	default:
 		// Unknown slash command - let Claude handle it (might be a custom command)
-		logger.Log("App: Unknown slash command /%s, passing to Claude", cmdName)
+		logger.Get().Debug("unknown slash command, passing to Claude", "command", cmdName)
 		return SlashCommandResult{Handled: false}
 	}
 }
@@ -168,7 +168,7 @@ func handleCostCommand(m *Model, _ string) SlashCommandResult {
 	// Find the Claude session JSONL file
 	stats, err := getSessionUsageStats(sessionID, workingDir)
 	if err != nil {
-		logger.Log("App: Failed to get session usage stats: %v", err)
+		logger.WithSession(sessionID).Warn("failed to get session usage stats", "error", err)
 		return SlashCommandResult{
 			Handled:  true,
 			Response: fmt.Sprintf("Could not retrieve usage data: %v", err),
@@ -216,7 +216,7 @@ func getSessionUsageStats(sessionID string, workingDir string) (*UsageStats, err
 
 	jsonlPath := filepath.Join(homeDir, ".claude", "projects", escapedPath, sessionID+".jsonl")
 
-	logger.Log("App: Looking for session JSONL at: %s", jsonlPath)
+	logger.Get().Debug("looking for session JSONL", "path", jsonlPath)
 
 	data, err := os.ReadFile(jsonlPath)
 	if err != nil {

--- a/internal/clipboard/clipboard_other.go
+++ b/internal/clipboard/clipboard_other.go
@@ -23,13 +23,15 @@ func Init() error {
 		return nil
 	}
 
+	log := logger.WithComponent("clipboard")
+
 	if err := clipboard.Init(); err != nil {
-		logger.Log("Clipboard: Failed to initialize: %v", err)
+		log.Error("failed to initialize", "error", err)
 		return fmt.Errorf("failed to initialize clipboard: %w", err)
 	}
 
 	initialized = true
-	logger.Log("Clipboard: Initialized successfully")
+	log.Debug("initialized successfully")
 	return nil
 }
 
@@ -43,19 +45,21 @@ func ReadImage() (*ImageData, error) {
 		}
 	}
 
+	log := logger.WithComponent("clipboard")
+
 	// Read image bytes from clipboard
 	imgBytes := clipboard.Read(clipboard.FmtImage)
 	if len(imgBytes) == 0 {
-		logger.Log("Clipboard: No image data found")
+		log.Debug("no image data found")
 		return nil, nil // No image in clipboard, not an error
 	}
 
-	logger.Log("Clipboard: Read %d bytes of image data", len(imgBytes))
+	log.Debug("read image data", "bytes", len(imgBytes))
 
 	// Decode the image to get dimensions
 	img, format, err := image.Decode(bytes.NewReader(imgBytes))
 	if err != nil {
-		logger.Log("Clipboard: Failed to decode image: %v", err)
+		log.Debug("failed to decode image", "error", err)
 		return nil, fmt.Errorf("failed to decode clipboard image: %w", err)
 	}
 
@@ -63,17 +67,17 @@ func ReadImage() (*ImageData, error) {
 	width := bounds.Dx()
 	height := bounds.Dy()
 
-	logger.Log("Clipboard: Image decoded: %dx%d, format=%s", width, height, format)
+	log.Debug("image decoded", "width", width, "height", height, "format", format)
 
 	// Re-encode as PNG for consistent format
 	var pngBuf bytes.Buffer
 	if err := png.Encode(&pngBuf, img); err != nil {
-		logger.Log("Clipboard: Failed to encode as PNG: %v", err)
+		log.Debug("failed to encode as PNG", "error", err)
 		return nil, fmt.Errorf("failed to encode image as PNG: %w", err)
 	}
 
 	pngBytes := pngBuf.Bytes()
-	logger.Log("Clipboard: Re-encoded to PNG: %d bytes", len(pngBytes))
+	log.Debug("re-encoded to PNG", "bytes", len(pngBytes))
 
 	return &ImageData{
 		Data:      pngBytes,
@@ -91,7 +95,8 @@ func WriteText(text string) error {
 		}
 	}
 
+	log := logger.WithComponent("clipboard")
 	clipboard.Write(clipboard.FmtText, []byte(text))
-	logger.Log("Clipboard: Wrote %d bytes of text", len(text))
+	log.Debug("wrote text", "bytes", len(text))
 	return nil
 }

--- a/internal/git/commit_helpers.go
+++ b/internal/git/commit_helpers.go
@@ -59,7 +59,7 @@ func (s *GitService) CommitWithMessage(
 		// Try to generate commit message with Claude, fall back to simple message
 		commitMsg, err = s.GenerateCommitMessageWithClaude(ctx, worktreePath)
 		if err != nil {
-			logger.Log("Git: Claude commit message failed, using fallback: %v", err)
+			logger.WithComponent("git").Warn("Claude commit message failed, using fallback", "error", err)
 			progressFn("Claude unavailable, using fallback message...\n")
 			commitMsg, err = s.GenerateCommitMessage(ctx, worktreePath)
 			if err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/zhubert/plural/internal/logger"
 )
 
 func TestBuildToolDescription(t *testing.T) {
@@ -729,6 +731,7 @@ func TestHandleExitPlanMode_EmptyPlanShowsUI(t *testing.T) {
 			planApprovalChan: planApprovalChan,
 			planResponseChan: planResponseChan,
 			writer:           &buf,
+			log:              logger.WithSession("test"),
 		}
 
 		go func() {
@@ -752,6 +755,7 @@ func TestHandleExitPlanMode_EmptyPlanShowsUI(t *testing.T) {
 			planApprovalChan: planApprovalChan,
 			planResponseChan: planResponseChan,
 			writer:           &buf,
+			log:              logger.WithSession("test"),
 		}
 
 		go func() {
@@ -784,6 +788,7 @@ func TestHandleExitPlanMode_EmptyPlanShowsUI(t *testing.T) {
 			planApprovalChan: planApprovalChan,
 			planResponseChan: planResponseChan,
 			writer:           &buf,
+			log:              logger.WithSession("test"),
 		}
 
 		go func() {
@@ -802,6 +807,8 @@ func TestHandleExitPlanMode_EmptyPlanShowsUI(t *testing.T) {
 }
 
 func TestReadPlanFromPath(t *testing.T) {
+	s := &Server{log: logger.WithSession("test")}
+
 	t.Run("reads existing file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		planContent := "# Test Plan\n\n1. Step one\n2. Step two"
@@ -810,14 +817,14 @@ func TestReadPlanFromPath(t *testing.T) {
 			t.Fatalf("Failed to write plan file: %v", err)
 		}
 
-		result := readPlanFromPath(planPath)
+		result := s.readPlanFromPath(planPath)
 		if result != planContent {
 			t.Errorf("readPlanFromPath() = %q, want %q", result, planContent)
 		}
 	})
 
 	t.Run("returns error message when file missing", func(t *testing.T) {
-		result := readPlanFromPath("/nonexistent/path/plan.md")
+		result := s.readPlanFromPath("/nonexistent/path/plan.md")
 		if !strings.Contains(result, "Plan file not found") {
 			t.Errorf("Expected 'Plan file not found' message, got: %q", result)
 		}
@@ -833,6 +840,7 @@ func TestHandleExitPlanMode_ParsesAllowedPrompts(t *testing.T) {
 		planApprovalChan: planApprovalChan,
 		planResponseChan: planResponseChan,
 		writer:           &buf,
+		log:              logger.WithSession("test"),
 	}
 
 	arguments := map[string]interface{}{

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -35,10 +35,11 @@ func ResetNotifier() {
 // On Linux, it uses D-Bus or notify-send.
 // On Windows, it uses the Windows Runtime COM API.
 func Send(title, message string) error {
-	logger.Log("Notification: Sending notification - title=%q, message=%q", title, message)
+	log := logger.WithComponent("notification")
+	log.Debug("sending notification", "title", title, "message", message)
 	err := notifier(title, message, icon)
 	if err != nil {
-		logger.Log("Notification: Failed to send notification: %v", err)
+		log.Error("failed to send notification", "error", err)
 	}
 	return err
 }

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -212,8 +212,14 @@ func (c *Chat) SetSize(width, height int) {
 		c.updateContent()
 	}
 
-	ctx.Log("Chat.SetSize: outer=%dx%d, chatPanel=%d, input=%d", width, height, chatPanelHeight, InputTotalHeight)
-	ctx.Log("  Chat viewport: w=%d, h=%d", c.viewport.Width(), c.viewport.Height())
+	ctx.Log("Chat.SetSize",
+		"outerWidth", width,
+		"outerHeight", height,
+		"chatPanelHeight", chatPanelHeight,
+		"inputTotalHeight", InputTotalHeight,
+		"viewportWidth", c.viewport.Width(),
+		"viewportHeight", c.viewport.Height(),
+	)
 }
 
 // SetFocused sets the focus state
@@ -349,7 +355,7 @@ func (c *Chat) AddSystemMessage(content string) {
 // GetInput returns the current input text
 func (c *Chat) GetInput() string {
 	val := strings.TrimSpace(c.input.Value())
-	logger.Log("Chat.GetInput: value=%q, len=%d", val, len(val))
+	logger.Get().Debug("Chat.GetInput", "value", val, "len", len(val))
 	return val
 }
 

--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -34,14 +34,15 @@ func GetViewContext() *ViewContext {
 			HeaderHeight: HeaderHeight,
 			FooterHeight: FooterHeight,
 		}
-		ctx.Log("ViewContext initialized")
+		logger.WithComponent("ui").Debug("ViewContext initialized")
 	})
 	return ctx
 }
 
-// Log writes a debug message to the log file
-func (v *ViewContext) Log(format string, args ...interface{}) {
-	logger.Log(format, args...)
+// Log writes a debug message to the log file using slog structured logging.
+// For new code, prefer using logger.WithComponent("ui").Debug() directly.
+func (v *ViewContext) Log(msg string, args ...interface{}) {
+	logger.WithComponent("ui").Debug(msg, args...)
 }
 
 // UpdateTerminalSize recalculates all dimensions when terminal size changes.
@@ -74,13 +75,16 @@ func (v *ViewContext) UpdateTerminalSize(width, height int) {
 	v.SidebarWidth = width / SidebarWidthRatio
 	v.ChatWidth = width - v.SidebarWidth
 
-	v.Log("Terminal size updated: %dx%d", width, height)
-	v.Log("  HeaderHeight: %d", v.HeaderHeight)
-	v.Log("  FooterHeight: %d", v.FooterHeight)
-	v.Log("  ContentHeight: %d (terminal %d - header %d - footer %d)",
-		v.ContentHeight, height, v.HeaderHeight, v.FooterHeight)
-	v.Log("  SidebarWidth: %d", v.SidebarWidth)
-	v.Log("  ChatWidth: %d", v.ChatWidth)
+	log := logger.WithComponent("ui")
+	log.Debug("Terminal size updated",
+		"width", width,
+		"height", height,
+		"headerHeight", v.HeaderHeight,
+		"footerHeight", v.FooterHeight,
+		"contentHeight", v.ContentHeight,
+		"sidebarWidth", v.SidebarWidth,
+		"chatWidth", v.ChatWidth,
+	)
 }
 
 // InnerWidth returns the usable width inside a panel with borders

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -84,7 +84,12 @@ func (s *Sidebar) SetSize(width, height int) {
 	s.height = height
 
 	ctx := GetViewContext()
-	ctx.Log("Sidebar.SetSize: outer=%dx%d, inner=%dx%d", width, height, ctx.InnerWidth(width), ctx.InnerHeight(height))
+	ctx.Log("Sidebar.SetSize",
+		"outerWidth", width,
+		"outerHeight", height,
+		"innerWidth", ctx.InnerWidth(width),
+		"innerHeight", ctx.InnerHeight(height),
+	)
 }
 
 // Width returns the sidebar width
@@ -272,12 +277,13 @@ func (s *Sidebar) SelectSession(id string) {
 
 // SetStreaming sets the streaming state for a session
 func (s *Sidebar) SetStreaming(sessionID string, streaming bool) {
+	log := logger.WithComponent("sidebar")
 	if streaming {
 		s.streamingSessions[sessionID] = true
-		logger.Info("Sidebar: SetStreaming(%s, true), total streaming: %d", sessionID, len(s.streamingSessions))
+		log.Info("SetStreaming", "sessionID", sessionID, "streaming", true, "totalStreaming", len(s.streamingSessions))
 	} else {
 		delete(s.streamingSessions, sessionID)
-		logger.Info("Sidebar: SetStreaming(%s, false), total streaming: %d", sessionID, len(s.streamingSessions))
+		log.Info("SetStreaming", "sessionID", sessionID, "streaming", false, "totalStreaming", len(s.streamingSessions))
 	}
 }
 

--- a/internal/ui/text_selection.go
+++ b/internal/ui/text_selection.go
@@ -350,7 +350,7 @@ func (c *Chat) CopySelectedText() tea.Cmd {
 		// Native clipboard fallback - returns error message if it fails
 		func() tea.Msg {
 			if err := clipboard.WriteText(selectedText); err != nil {
-				logger.Log("Failed to write to clipboard: %v", err)
+				logger.Get().Error("Failed to write to clipboard", "error", err)
 				return ClipboardErrorMsg{Error: err}
 			}
 			return nil

--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func runMCPServer() {
 	}()
 
 	// Run MCP server on stdin/stdout
-	server := mcp.NewServer(os.Stdin, os.Stdout, reqChan, respChan, questionChan, answerChan, planApprovalChan, planResponseChan, nil)
+	server := mcp.NewServer(os.Stdin, os.Stdout, reqChan, respChan, questionChan, answerChan, planApprovalChan, planResponseChan, nil, sessionID)
 	if err := server.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "MCP server error: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
Migrates all logging calls from printf-style `logger.Log/Info/Error/Warn/Debug` functions to structured logging using Go's `log/slog` package via `logger.Get()` and `logger.WithSession()` helper methods.

## Changes
- Replace `logger.Log("format", args...)` with `logger.Get().Debug("message", "key", value, ...)`
- Replace `logger.Info/Error/Warn/Debug("format", args...)` with structured equivalents
- Use `logger.WithSession(sessionID)` for session-scoped logging to automatically include session context
- Remove "App:" and "SessionManager:" prefixes from log messages (context now provided by structured fields)
- Convert format string arguments to key-value pairs for structured logging

## Test plan
- Run `go test ./...` to verify all tests pass
- Run `./plural --debug` and verify logs are properly formatted
- Check `/tmp/plural-debug.log` to confirm structured log output with proper key-value pairs
- Verify session-scoped logs include the session ID field