### PR TITLE
Add exit command with confirmation modal for active sessions

### DIFF
--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -27,6 +27,8 @@ func (m *Model) handleModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmDeleteModal(key, msg, s)
 	case *ui.ConfirmDeleteRepoState:
 		return m.handleConfirmDeleteRepoModal(key, msg, s)
+	case *ui.ConfirmExitState:
+		return m.handleConfirmExitModal(key, msg, s)
 	case *ui.ForkSessionState:
 		return m.handleForkSessionModal(key, msg, s)
 	case *ui.RenameSessionState:

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -378,3 +378,26 @@ func (m *Model) handleConfirmDeleteRepoModal(key string, msg tea.KeyPressMsg, st
 	}
 	return m, nil
 }
+
+// handleConfirmExitModal handles key events for the Confirm Exit modal.
+func (m *Model) handleConfirmExitModal(key string, msg tea.KeyPressMsg, state *ui.ConfirmExitState) (tea.Model, tea.Cmd) {
+	switch key {
+	case "esc":
+		m.modal.Hide()
+		return m, nil
+	case "enter":
+		if state.ShouldExit() {
+			logger.Get().Info("user confirmed exit with active sessions")
+			return m, tea.Quit
+		}
+		// Cancel selected
+		m.modal.Hide()
+		return m, nil
+	case "up", "down", "j", "k":
+		// Forward navigation keys to modal for option selection
+		modal, cmd := m.modal.Update(msg)
+		m.modal = modal
+		return m, cmd
+	}
+	return m, nil
+}

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -33,6 +33,7 @@ type (
 	MergeConflictState      = modals.MergeConflictState
 	ConfirmDeleteState      = modals.ConfirmDeleteState
 	ConfirmDeleteRepoState  = modals.ConfirmDeleteRepoState
+	ConfirmExitState        = modals.ConfirmExitState
 	MCPServersState         = modals.MCPServersState
 	AddMCPServerState       = modals.AddMCPServerState
 	PluginsState            = modals.PluginsState
@@ -59,6 +60,7 @@ var (
 	NewMergeConflictState      = modals.NewMergeConflictState
 	NewConfirmDeleteState      = modals.NewConfirmDeleteState
 	NewConfirmDeleteRepoState  = modals.NewConfirmDeleteRepoState
+	NewConfirmExitState        = modals.NewConfirmExitState
 	NewMCPServersState         = modals.NewMCPServersState
 	NewAddMCPServerState       = modals.NewAddMCPServerState
 	NewPluginsState            = modals.NewPluginsState


### PR DESCRIPTION
## Summary
Adds an "exit" text command that allows users to quit Plural from the chat input. When there are active Claude sessions running, a confirmation modal is shown to prevent accidental termination of processes.

## Changes
- Add exit command detection in `sendMessage()` that intercepts "exit" input (case-insensitive, whitespace-tolerant)
- Implement `handleExitCommand()` that checks for active runners and either quits immediately or shows confirmation
- Add `ConfirmExitState` modal with session count display and Cancel/Exit options
- Add `handleConfirmExitModal()` for keyboard navigation (up/down/j/k) and selection (Enter/Esc)
- Exit command is only triggered for text-only input (not when an image is attached)

## Test plan
- Run `go test ./internal/app/...` to verify all new tests pass
- Test manually:
  - Type "exit" with no active sessions → should quit immediately
  - Type "exit" with active sessions → should show confirmation modal
  - In modal: press Esc or Enter on Cancel → should close modal
  - In modal: navigate to Exit with down/j, press Enter → should quit
  - Type "EXIT", "Exit", "  exit  " → all should work (case-insensitive)
  - Attach an image and type "exit" → should not trigger exit command