### PR TITLE
Add streaming status with elapsed time and token count

### DIFF
--- a/internal/app/msg_handlers.go
+++ b/internal/app/msg_handlers.go
@@ -153,6 +153,11 @@ func (m *Model) handleClaudeStreaming(sessionID string, chunk claude.ResponseChu
 				m.sessionState().GetOrCreate(sessionID).SetCurrentTodoList(chunk.TodoList)
 				m.chat.SetTodoList(chunk.TodoList)
 			}
+		case claude.ChunkTypeStreamStats:
+			// Update streaming statistics display
+			if chunk.Stats != nil {
+				m.chat.SetStreamStats(chunk.Stats)
+			}
 		default:
 			// For backwards compatibility, treat unknown types as text
 			if chunk.Content != "" {

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -1704,3 +1704,95 @@ func TestChunkTypeTodoUpdate(t *testing.T) {
 		t.Errorf("ChunkTypeTodoUpdate = %q, want %q", ChunkTypeTodoUpdate, "todo_update")
 	}
 }
+
+func TestChunkTypeStreamStats(t *testing.T) {
+	// Verify the constant value
+	if ChunkTypeStreamStats != "stream_stats" {
+		t.Errorf("ChunkTypeStreamStats = %q, want %q", ChunkTypeStreamStats, "stream_stats")
+	}
+}
+
+func TestStreamMessage_UsageFields(t *testing.T) {
+	// Test that usage fields are properly parsed from the result message JSON
+	jsonMsg := `{
+		"type": "result",
+		"subtype": "success",
+		"is_error": false,
+		"duration_ms": 4391,
+		"duration_api_ms": 3652,
+		"num_turns": 1,
+		"result": "Hello!",
+		"total_cost_usd": 0.2644345,
+		"usage": {
+			"input_tokens": 3,
+			"cache_creation_input_tokens": 41012,
+			"cache_read_input_tokens": 15539,
+			"output_tokens": 13
+		}
+	}`
+
+	var msg streamMessage
+	if err := json.Unmarshal([]byte(jsonMsg), &msg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if msg.Type != "result" {
+		t.Errorf("Expected type 'result', got %q", msg.Type)
+	}
+
+	if msg.Subtype != "success" {
+		t.Errorf("Expected subtype 'success', got %q", msg.Subtype)
+	}
+
+	if msg.DurationMs != 4391 {
+		t.Errorf("Expected duration_ms 4391, got %d", msg.DurationMs)
+	}
+
+	if msg.DurationAPIMs != 3652 {
+		t.Errorf("Expected duration_api_ms 3652, got %d", msg.DurationAPIMs)
+	}
+
+	if msg.NumTurns != 1 {
+		t.Errorf("Expected num_turns 1, got %d", msg.NumTurns)
+	}
+
+	if msg.TotalCostUSD != 0.2644345 {
+		t.Errorf("Expected total_cost_usd 0.2644345, got %f", msg.TotalCostUSD)
+	}
+
+	if msg.Usage == nil {
+		t.Fatal("Expected usage to be non-nil")
+	}
+
+	if msg.Usage.InputTokens != 3 {
+		t.Errorf("Expected input_tokens 3, got %d", msg.Usage.InputTokens)
+	}
+
+	if msg.Usage.CacheCreationInputTokens != 41012 {
+		t.Errorf("Expected cache_creation_input_tokens 41012, got %d", msg.Usage.CacheCreationInputTokens)
+	}
+
+	if msg.Usage.CacheReadInputTokens != 15539 {
+		t.Errorf("Expected cache_read_input_tokens 15539, got %d", msg.Usage.CacheReadInputTokens)
+	}
+
+	if msg.Usage.OutputTokens != 13 {
+		t.Errorf("Expected output_tokens 13, got %d", msg.Usage.OutputTokens)
+	}
+}
+
+func TestStreamStats(t *testing.T) {
+	// Test StreamStats struct
+	stats := StreamStats{
+		OutputTokens: 1500,
+		TotalCostUSD: 0.25,
+	}
+
+	if stats.OutputTokens != 1500 {
+		t.Errorf("Expected OutputTokens 1500, got %d", stats.OutputTokens)
+	}
+
+	if stats.TotalCostUSD != 0.25 {
+		t.Errorf("Expected TotalCostUSD 0.25, got %f", stats.TotalCostUSD)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a real-time status display during Claude streaming that shows elapsed time, token count, and an escape hint. This gives users better visibility into ongoing requests.

## Changes
- Add `StreamStats` type to track output tokens and cost from Claude's result messages
- Parse `usage` and `total_cost_usd` fields from Claude's stream-json output
- Emit `ChunkTypeStreamStats` chunk when result message contains usage data
- Update chat UI to display status line: `✺ Thinking... (esc to interrupt • 12s • ↓ 342 tokens)`
- Track stream start time for elapsed duration calculation
- Add debug logging for raw stream messages

## Test plan
- Run `go test ./...` to verify all tests pass
- Start a session and send a message to Claude
- Verify the status line appears below the spinner showing:
  - "esc to interrupt" hint
  - Elapsed time updating in real-time
  - Token count appearing once streaming completes
- Test that token count formats correctly (e.g., "342" vs "1.4k" for 1400+)