### PR TITLE
Initialize empty slice explicitly in GetLogFiles

### DIFF
--- a/internal/ui/view_logs.go
+++ b/internal/ui/view_logs.go
@@ -12,8 +12,9 @@ import (
 
 // GetLogFiles returns a list of available log files for viewing.
 // It finds the main debug log and any session-specific MCP/stream logs.
+// Always returns a non-nil slice (may be empty if no log files found).
 func GetLogFiles(currentSessionID string) []LogFile {
-	var files []LogFile
+	files := []LogFile{}
 
 	// Main debug log
 	if _, err := os.Stat(logger.DefaultLogPath); err == nil {


### PR DESCRIPTION
## Summary
Changes `GetLogFiles` to explicitly initialize an empty slice instead of using a nil slice declaration, ensuring consistent return behavior.

## Changes
- Replace `var files []LogFile` with `files := []LogFile{}` for explicit empty slice initialization
- Add documentation clarifying that the function always returns a non-nil slice

## Test plan
- Run `go test ./internal/ui/...` to verify existing tests pass
- Verify that callers of `GetLogFiles` handle the return value correctly (no nil checks needed)