### PR TITLE
Fix MCP path traversal and socket write deadline

### DIFF
--- a/internal/mcp/socket.go
+++ b/internal/mcp/socket.go
@@ -282,7 +282,7 @@ func (s *SocketServer) sendPermissionResponse(conn net.Conn, resp PermissionResp
 		return
 	}
 
-	conn.SetWriteDeadline(time.Now().Add(SocketReadTimeout))
+	conn.SetWriteDeadline(time.Now().Add(SocketWriteTimeout))
 	if _, err := conn.Write(append(respJSON, '\n')); err != nil {
 		s.log.Error("write error", "error", err)
 	}
@@ -299,7 +299,7 @@ func (s *SocketServer) sendQuestionResponse(conn net.Conn, resp QuestionResponse
 		return
 	}
 
-	conn.SetWriteDeadline(time.Now().Add(SocketReadTimeout))
+	conn.SetWriteDeadline(time.Now().Add(SocketWriteTimeout))
 	if _, err := conn.Write(append(respJSON, '\n')); err != nil {
 		s.log.Error("write error", "error", err)
 	}
@@ -355,7 +355,7 @@ func (s *SocketServer) sendPlanApprovalResponse(conn net.Conn, resp PlanApproval
 		return
 	}
 
-	conn.SetWriteDeadline(time.Now().Add(SocketReadTimeout))
+	conn.SetWriteDeadline(time.Now().Add(SocketWriteTimeout))
 	if _, err := conn.Write(append(respJSON, '\n')); err != nil {
 		s.log.Error("write error", "error", err)
 	}


### PR DESCRIPTION
## Summary
- **Security**: Added path validation in `readPlanFromPath` to restrict file reads to `~/.claude/plans/`, preventing path traversal attacks
- **Bug fix**: Corrected 3 `SetWriteDeadline` calls in `internal/mcp/socket.go` that were using `SocketReadTimeout` instead of `SocketWriteTimeout`

## Test plan
- [x] Added `TestValidatePlanPath` with 7 cases (valid path, traversal, absolute outside, prefix attack, relative, home dir, sibling dir)
- [x] Updated existing plan tests to use actual `~/.claude/plans/` directory
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)