### PR TITLE
Fix race condition on DetectedOptions access

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1192,7 +1192,7 @@ func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInt
 	state := m.sessionState().GetOrCreate(sessionID)
 	msgs := runner.GetMessages()
 	if len(msgs) == 0 {
-		state.DetectedOptions = nil
+		state.SetDetectedOptions(nil)
 		return
 	}
 
@@ -1202,7 +1202,7 @@ func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInt
 			options := DetectOptions(msgs[i].Content)
 			if len(options) >= 2 {
 				logger.WithSession(sessionID).Debug("detected options", "count", len(options))
-				state.DetectedOptions = options
+				state.SetDetectedOptions(options)
 				return
 			}
 			break // Only check the most recent assistant message
@@ -1210,7 +1210,7 @@ func (m *Model) detectOptionsInSession(sessionID string, runner claude.RunnerInt
 	}
 
 	// No options found
-	state.DetectedOptions = nil
+	state.SetDetectedOptions(nil)
 }
 
 // showExploreOptionsModal displays the modal for selecting options to explore in parallel
@@ -1223,7 +1223,7 @@ func (m *Model) showExploreOptionsModal() (tea.Model, tea.Cmd) {
 	if state == nil || !state.HasDetectedOptions() {
 		return m, nil
 	}
-	options := state.DetectedOptions
+	options := state.GetDetectedOptions()
 
 	// Convert to UI option items
 	items := make([]ui.OptionItem, len(options))

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -1953,8 +1953,8 @@ Let me know which you prefer.`)
 	}
 
 	// Verify the correct number of options
-	if len(stateA.DetectedOptions) != 3 {
-		t.Errorf("Expected 3 detected options, got %d", len(stateA.DetectedOptions))
+	if opts := stateA.GetDetectedOptions(); len(opts) != 3 {
+		t.Errorf("Expected 3 detected options, got %d", len(opts))
 	}
 }
 
@@ -1977,10 +1977,10 @@ func TestSessionSelect_ClearsOptionsWhenNoOptions(t *testing.T) {
 
 	// Manually set some detected options to verify they get cleared
 	stateA := m.sessionState().GetOrCreate(sessionA)
-	stateA.DetectedOptions = []DetectedOption{
+	stateA.SetDetectedOptions([]DetectedOption{
 		{Number: 1, Text: "Fake option"},
 		{Number: 2, Text: "Another fake"},
-	}
+	})
 
 	// Switch away and back
 	m = sendKey(m, "tab")
@@ -2038,8 +2038,8 @@ Which would you prefer?`},
 		t.Error("Options should be detected on initial session selection")
 	}
 
-	if len(state.DetectedOptions) != 2 {
-		t.Errorf("Expected 2 detected options, got %d", len(state.DetectedOptions))
+	if opts := state.GetDetectedOptions(); len(opts) != 2 {
+		t.Errorf("Expected 2 detected options, got %d", len(opts))
 	}
 }
 

--- a/internal/app/modal_handlers_issues.go
+++ b/internal/app/modal_handlers_issues.go
@@ -406,7 +406,7 @@ func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Mod
 
 	// Clear detected options since we've acted on them
 	if state := m.sessionState().GetIfExists(parentSession.ID); state != nil {
-		state.DetectedOptions = nil
+		state.SetDetectedOptions(nil)
 	}
 
 	// Start all sessions in parallel

--- a/internal/app/session_state.go
+++ b/internal/app/session_state.go
@@ -88,6 +88,27 @@ func (s *SessionState) HasDetectedOptions() bool {
 	return len(s.DetectedOptions) >= 2
 }
 
+// GetDetectedOptions returns a copy of the detected options slice.
+// Thread-safe.
+func (s *SessionState) GetDetectedOptions() []DetectedOption {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.DetectedOptions == nil {
+		return nil
+	}
+	result := make([]DetectedOption, len(s.DetectedOptions))
+	copy(result, s.DetectedOptions)
+	return result
+}
+
+// SetDetectedOptions sets the detected options.
+// Thread-safe.
+func (s *SessionState) SetDetectedOptions(options []DetectedOption) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.DetectedOptions = options
+}
+
 // HasTodoList returns true if there is a non-empty todo list.
 // Thread-safe.
 func (s *SessionState) HasTodoList() bool {

--- a/internal/app/session_state_test.go
+++ b/internal/app/session_state_test.go
@@ -429,11 +429,11 @@ func TestSessionState_HelperMethods(t *testing.T) {
 	if state.HasDetectedOptions() {
 		t.Error("expected HasDetectedOptions to be false with empty slice")
 	}
-	state.DetectedOptions = []DetectedOption{{Number: 1}}
+	state.SetDetectedOptions([]DetectedOption{{Number: 1}})
 	if state.HasDetectedOptions() {
 		t.Error("expected HasDetectedOptions to be false with single option")
 	}
-	state.DetectedOptions = []DetectedOption{{Number: 1}, {Number: 2}}
+	state.SetDetectedOptions([]DetectedOption{{Number: 1}, {Number: 2}})
 	if !state.HasDetectedOptions() {
 		t.Error("expected HasDetectedOptions to be true with 2+ options")
 	}


### PR DESCRIPTION
## Summary
- Added thread-safe `GetDetectedOptions()` and `SetDetectedOptions()` accessors to `SessionState`
- `GetDetectedOptions()` returns a copy of the slice to prevent aliasing
- Updated all callers across `app.go`, `modal_handlers_issues.go`, and tests

## Test plan
- [x] Updated `session_state_test.go` to use new accessors
- [x] Updated `integration_test.go` to use new accessors
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)