### PR TITLE
Fix incorrect sidebar width comment

### DIFF
--- a/internal/ui/context.go
+++ b/internal/ui/context.go
@@ -71,7 +71,7 @@ func (v *ViewContext) UpdateTerminalSize(width, height int) {
 	// Content area is everything between header and footer
 	v.ContentHeight = height - v.HeaderHeight - v.FooterHeight
 
-	// Sidebar is 1/3 of width, chat gets the rest
+	// Sidebar is 1/5 of width, chat gets the rest
 	v.SidebarWidth = width / SidebarWidthRatio
 	v.ChatWidth = width - v.SidebarWidth
 


### PR DESCRIPTION
## Summary
- Comment in `context.go` said "Sidebar is 1/3 of width" but `SidebarWidthRatio = 5` means it's actually 1/5
- Updated comment to match the code

## Test plan
- [x] Comment-only change
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)