### PR TITLE
Return copy from Config.GetSession to prevent slice aliasing

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -167,6 +167,27 @@ func TestConfig_GetSession(t *testing.T) {
 	}
 }
 
+func TestConfig_GetSession_ReturnsCopy(t *testing.T) {
+	cfg := &Config{
+		Sessions: []Session{
+			{ID: "session-1", RepoPath: "/path1", Branch: "original"},
+		},
+	}
+
+	// Get session and modify the copy
+	sess := cfg.GetSession("session-1")
+	if sess == nil {
+		t.Fatal("GetSession should return session")
+	}
+	sess.Branch = "modified"
+
+	// Original in config should be unchanged
+	sess2 := cfg.GetSession("session-1")
+	if sess2.Branch != "original" {
+		t.Errorf("GetSession should return a copy; modifying it should not affect config, got branch=%q", sess2.Branch)
+	}
+}
+
 func TestConfig_AllowedTools(t *testing.T) {
 	cfg := &Config{
 		Repos:            []string{"/path/to/repo"},

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -90,14 +90,16 @@ func (c *Config) ClearSessions() {
 	c.Sessions = []Session{}
 }
 
-// GetSession returns a session by ID
+// GetSession returns a copy of a session by ID.
+// Returns nil if no session with the given ID exists.
 func (c *Config) GetSession(id string) *Session {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	for i := range c.Sessions {
 		if c.Sessions[i].ID == id {
-			return &c.Sessions[i]
+			sess := c.Sessions[i] // copy
+			return &sess
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- `GetSession` returned `&c.Sessions[i]` — a pointer directly into the internal slice
- This could become dangling if `AddSession` causes slice reallocation, and allowed unsynchronized mutation
- Now returns a pointer to a copy of the session
- All callers verified to be read-only, so this is a safe change

## Test plan
- [x] Added `TestConfig_GetSession_ReturnsCopy` verifying modifications to the returned pointer don't affect config
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)