### PR TITLE
Add repo management directly from new session modal

### DIFF
--- a/internal/ui/modal_test.go
+++ b/internal/ui/modal_test.go
@@ -262,20 +262,20 @@ func TestNewSessionState_Render(t *testing.T) {
 }
 
 func TestNewSessionState_Help(t *testing.T) {
-	// With repos, focused on repo list - should show delete hint
+	// With repos, focused on repo list - should show add and delete hints
 	state := NewNewSessionState([]string{"/repo1", "/repo2"})
 	state.Focus = 0
 	help := state.Help()
-	if help != "up/down: select  Tab: next field  d: delete repo  Enter: create" {
-		t.Errorf("Expected help with delete hint when focused on repos, got %q", help)
+	if help != "up/down: select  Tab: next field  a: add repo  d: delete repo  Enter: create" {
+		t.Errorf("Expected help with add/delete hints when focused on repos, got %q", help)
 	}
 
-	// Without repos, focused on repo list - should not show delete hint
+	// Without repos, focused on repo list - should show add hint
 	state = NewNewSessionState([]string{})
 	state.Focus = 0
 	help = state.Help()
-	if help != "up/down: select  Tab: next field  Enter: create" {
-		t.Errorf("Expected help without delete hint when no repos, got %q", help)
+	if help != "a: add repo  Esc: cancel" {
+		t.Errorf("Expected help with add hint when no repos, got %q", help)
 	}
 
 	// With repos, focused on base selection - should not show delete hint

--- a/internal/ui/modals/repo.go
+++ b/internal/ui/modals/repo.go
@@ -15,13 +15,14 @@ import (
 // =============================================================================
 
 type AddRepoState struct {
-	Input            textinput.Model
-	SuggestedRepo    string
-	UseSuggested     bool
-	completer        *PathCompleter // Path auto-completion
-	lastValue        string         // Track input changes to reset completer
-	showingOptions   bool           // Whether we're showing completion options
-	completionIndex  int            // Currently selected completion option
+	Input              textinput.Model
+	SuggestedRepo      string
+	UseSuggested       bool
+	ReturnToNewSession bool           // When true, return to new session modal after adding repo
+	completer          *PathCompleter // Path auto-completion
+	lastValue          string         // Track input changes to reset completer
+	showingOptions     bool           // Whether we're showing completion options
+	completionIndex    int            // Currently selected completion option
 }
 
 func (*AddRepoState) modalState() {}

--- a/internal/ui/modals/session.go
+++ b/internal/ui/modals/session.go
@@ -25,8 +25,11 @@ func (*NewSessionState) modalState() {}
 func (s *NewSessionState) Title() string { return "New Session" }
 
 func (s *NewSessionState) Help() string {
+	if s.Focus == 0 && len(s.RepoOptions) == 0 {
+		return "a: add repo  Esc: cancel"
+	}
 	if s.Focus == 0 && len(s.RepoOptions) > 0 {
-		return "up/down: select  Tab: next field  d: delete repo  Enter: create"
+		return "up/down: select  Tab: next field  a: add repo  d: delete repo  Enter: create"
 	}
 	return "up/down: select  Tab: next field  Enter: create"
 }
@@ -44,7 +47,7 @@ func (s *NewSessionState) Render() string {
 		repoList = lipgloss.NewStyle().
 			Foreground(ColorTextMuted).
 			Italic(true).
-			Render("No repositories added. Press 'r' to add one first.")
+			Render("No repositories added. Press 'a' to add one.")
 	} else {
 		repoList = RenderSelectableListWithFocus(s.RepoOptions, s.RepoIndex, s.Focus == 0, "* ")
 	}


### PR DESCRIPTION
## Summary

Adds the ability to add repositories directly from the new session modal via the 'a' keybinding. Previously, users had to exit the modal and press 'r' to add repos before creating a session.

**Changes:**
- Added 'a' keybinding in new session modal to open add repo modal
- Added `ReturnToNewSession` flag to control navigation flow
- When adding a repo from the new session modal, returns to new session modal instead of closing
- Updated help text and empty state message to guide users
- Added comprehensive integration tests for the new workflow

**Benefits:**
- Streamlined UX - users can add repos without breaking their flow
- Better discoverability - clear hints when no repos are available
- Maintains context - stays in session creation flow

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Manual testing:
  - [x] Open new session modal with no repos - shows "Press 'a' to add one"
  - [x] Press 'a' - opens add repo modal
  - [x] Add a repo and press Enter - returns to new session modal with repo listed
  - [x] Press Escape in add repo modal - returns to new session modal
  - [x] Press 'a' when focused on branch input - 'a' types into input (doesn't open modal)
  - [x] Delete repo with 'd' - still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)