### PR TITLE
Add Apple Container integration for sandboxed Claude sessions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,20 @@
+FROM node:22-slim
+
+# Install git (needed for worktree operations inside container)
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Install Claude CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create non-root user (Claude CLI refuses --dangerously-skip-permissions as root)
+RUN useradd -m -s /bin/bash claude
+USER claude
+
+# Entrypoint copies read-only host .claude config to a writable location
+# Host mounts ~/.claude at /home/claude/.claude-host:ro for security
+COPY --chown=claude:claude entrypoint.sh /home/claude/entrypoint.sh
+
+# Default working directory (overridden by -w flag)
+WORKDIR /workspace
+
+ENTRYPOINT ["/home/claude/entrypoint.sh"]

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -20,9 +20,9 @@ var skipConfirm bool
 
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "Remove all sessions, logs, and orphaned worktrees",
+	Short: "Remove all sessions, logs, orphaned worktrees, and containers",
 	Long: `Clears all session data, removes log files, prunes orphaned worktrees,
-and kills any orphaned Claude processes.
+kills any orphaned Claude processes, and removes orphaned containers.
 
 This command combines the functionality of the former --clear and --prune flags.
 It will prompt for confirmation before proceeding unless the --yes flag is used.`,
@@ -70,8 +70,13 @@ func runCleanWithReader(input io.Reader) error {
 		fmt.Fprintf(os.Stderr, "Warning: error finding orphaned processes: %v\n", err)
 	}
 
+	orphanContainers, err := process.FindOrphanedContainers(knownSessions)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: error finding orphaned containers: %v\n", err)
+	}
+
 	// Check if there's anything to clean
-	if sessionCount == 0 && len(orphanWorktrees) == 0 && len(orphanMessages) == 0 && len(orphanProcesses) == 0 {
+	if sessionCount == 0 && len(orphanWorktrees) == 0 && len(orphanMessages) == 0 && len(orphanProcesses) == 0 && len(orphanContainers) == 0 {
 		fmt.Println("Nothing to clean.")
 		return nil
 	}
@@ -94,6 +99,12 @@ func runCleanWithReader(input io.Reader) error {
 		fmt.Printf("  - %d orphaned process(es)\n", len(orphanProcesses))
 		for _, proc := range orphanProcesses {
 			fmt.Printf("      PID %d\n", proc.PID)
+		}
+	}
+	if len(orphanContainers) > 0 {
+		fmt.Printf("  - %d orphaned container(s)\n", len(orphanContainers))
+		for _, c := range orphanContainers {
+			fmt.Printf("      %s\n", c.Name)
 		}
 	}
 	fmt.Println("  - All log files in /tmp/plural-*")
@@ -126,11 +137,11 @@ func runCleanWithReader(input io.Reader) error {
 	sessionSvc := session.NewSessionService()
 	ctx := context.Background()
 
-	var prunedWorktrees, prunedMessages, prunedProcesses int
-	var worktreesErr, messagesErr, processesErr error
+	var prunedWorktrees, prunedMessages, prunedProcesses, prunedContainers int
+	var worktreesErr, messagesErr, processesErr, containersErr error
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 
 	go func() {
 		defer wg.Done()
@@ -147,6 +158,11 @@ func runCleanWithReader(input io.Reader) error {
 		prunedProcesses, processesErr = process.CleanupOrphanedProcesses(knownSessions)
 	}()
 
+	go func() {
+		defer wg.Done()
+		prunedContainers, containersErr = process.CleanupOrphanedContainers(knownSessions)
+	}()
+
 	wg.Wait()
 
 	// Report any errors
@@ -158,6 +174,9 @@ func runCleanWithReader(input io.Reader) error {
 	}
 	if processesErr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: error killing orphaned processes: %v\n", processesErr)
+	}
+	if containersErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: error removing orphaned containers: %v\n", containersErr)
 	}
 
 	// Print results
@@ -180,6 +199,9 @@ func runCleanWithReader(input io.Reader) error {
 	}
 	if prunedProcesses > 0 {
 		fmt.Printf("  - %d orphaned process(es) killed\n", prunedProcesses)
+	}
+	if prunedContainers > 0 {
+		fmt.Printf("  - %d orphaned container(s) removed\n", prunedContainers)
 	}
 
 	return nil

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Copy only needed config from host into writable location so Claude CLI
+# can write debug logs, todos, and session data. The host dir is mounted
+# read-only at .claude-host to prevent container writes from reaching the host.
+# Selective copy avoids slow startup for users with large ~/.claude directories.
+HOST_DIR=/home/claude/.claude-host
+DEST_DIR=/home/claude/.claude
+mkdir -p "$DEST_DIR"
+
+# Copy essential config files
+for f in settings.json CLAUDE.md; do
+    [ -f "$HOST_DIR/$f" ] && cp "$HOST_DIR/$f" "$DEST_DIR/$f" 2>/dev/null
+done
+
+# Copy projects dir (session JSONL files needed for fork/resume)
+[ -d "$HOST_DIR/projects" ] && cp -r "$HOST_DIR/projects" "$DEST_DIR/projects" 2>/dev/null
+
+# Copy plugins config
+[ -d "$HOST_DIR/plugins" ] && cp -r "$HOST_DIR/plugins" "$DEST_DIR/plugins" 2>/dev/null
+
+# Read auth credentials from mounted secrets file (not passed via -e to
+# avoid exposing the key in `ps` output on the host).
+# File format: ANTHROPIC_API_KEY='value' or CLAUDE_CODE_OAUTH_TOKEN='value'
+# Uses set -a to auto-export all variables, then sources the file.
+# This is safer than export "$(cat ...)" which breaks on newlines.
+if [ -f /home/claude/.auth ]; then
+    set -a
+    . /home/claude/.auth
+    set +a
+fi
+
+exec claude "$@"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -951,6 +951,8 @@ func (m *Model) selectSession(sess *config.Session) {
 	m.header.SetBaseBranch(result.BaseBranch)
 	// Show preview indicator if this session is being previewed
 	m.header.SetPreviewActive(m.config.GetPreviewSessionID() == sess.ID)
+	// Show container indicator if this session is containerized
+	m.header.SetContainerActive(sess.Containerized)
 	if result.DiffStats != nil {
 		m.header.SetDiffStats(&ui.DiffStats{
 			FilesChanged: result.DiffStats.FilesChanged,

--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -71,6 +71,8 @@ func (m *Model) handleModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleThemeModal(key, msg, s)
 	case *ui.SettingsState:
 		return m.handleSettingsModal(key, msg, s)
+	case *ui.ContainerBuildState:
+		return m.handleContainerBuildModal(key, msg, s)
 
 	// Navigation modals (modal_handlers_navigation.go)
 	case *ui.WelcomeState:

--- a/internal/app/modal_handlers_config.go
+++ b/internal/app/modal_handlers_config.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/google/uuid"
 	"github.com/zhubert/plural/internal/claude"
+	"github.com/zhubert/plural/internal/clipboard"
 	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/keys"
 	"github.com/zhubert/plural/internal/logger"
@@ -369,4 +370,21 @@ func (m *Model) handleSettingsModal(key string, msg tea.KeyPressMsg, state *ui.S
 	modal, cmd := m.modal.Update(msg)
 	m.modal = modal
 	return m, cmd
+}
+
+// handleContainerBuildModal handles key events for the Container Build modal.
+func (m *Model) handleContainerBuildModal(key string, _ tea.KeyPressMsg, state *ui.ContainerBuildState) (tea.Model, tea.Cmd) {
+	switch key {
+	case keys.Escape:
+		m.modal.Hide()
+		return m, nil
+	case keys.Enter:
+		if err := clipboard.WriteText(state.GetBuildCommand()); err != nil {
+			logger.Get().Error("failed to copy to clipboard", "error", err)
+			return m, m.ShowFlashError("Failed to copy to clipboard")
+		}
+		state.Copied = true
+		return m, nil
+	}
+	return m, nil
 }

--- a/internal/app/modal_handlers_issues.go
+++ b/internal/app/modal_handlers_issues.go
@@ -388,6 +388,8 @@ func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Mod
 
 		// Set parent ID to track fork relationship
 		sess.ParentID = parentSession.ID
+		// Inherit containerized flag from parent
+		sess.Containerized = parentSession.Containerized
 		// Auto-assign to active workspace
 		if activeWS := m.config.GetActiveWorkspaceID(); activeWS != "" {
 			sess.WorkspaceID = activeWS

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -325,19 +325,25 @@ func (sm *SessionManager) GetOrCreateRunner(sess *config.Session) claude.RunnerI
 		runner.SetAllowedTools(allowedTools)
 	}
 
-	// Load MCP servers for this session's repo
-	mcpServers := sm.config.GetMCPServersForRepo(sess.RepoPath)
-	if len(mcpServers) > 0 {
-		log.Debug("loaded MCP servers", "count", len(mcpServers), "repo", sess.RepoPath)
-		var servers []claude.MCPServer
-		for _, s := range mcpServers {
-			servers = append(servers, claude.MCPServer{
-				Name:    s.Name,
-				Command: s.Command,
-				Args:    s.Args,
-			})
+	// Configure container mode if enabled for this session
+	if sess.Containerized {
+		runner.SetContainerized(true, sm.config.GetContainerImage())
+		log.Debug("containerized session, MCP servers not used in container mode")
+	} else {
+		// Load MCP servers for this session's repo (only for non-containerized sessions)
+		mcpServers := sm.config.GetMCPServersForRepo(sess.RepoPath)
+		if len(mcpServers) > 0 {
+			log.Debug("loaded MCP servers", "count", len(mcpServers), "repo", sess.RepoPath)
+			var servers []claude.MCPServer
+			for _, s := range mcpServers {
+				servers = append(servers, claude.MCPServer{
+					Name:    s.Name,
+					Command: s.Command,
+					Args:    s.Args,
+				})
+			}
+			runner.SetMCPServers(servers)
 		}
-		runner.SetMCPServers(servers)
 	}
 
 	return runner

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/zhubert/plural/internal/claude"
 	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/git"
 	"github.com/zhubert/plural/internal/keys"
 	"github.com/zhubert/plural/internal/logger"
+	"github.com/zhubert/plural/internal/process"
 	"github.com/zhubert/plural/internal/ui"
 )
 
@@ -433,7 +435,7 @@ func shortcutSearch(m *Model) (tea.Model, tea.Cmd) {
 }
 
 func shortcutNewSession(m *Model) (tea.Model, tea.Cmd) {
-	m.modal.Show(ui.NewNewSessionState(m.config.GetRepos()))
+	m.modal.Show(ui.NewNewSessionState(m.config.GetRepos(), process.ContainersSupported(), claude.ContainerAuthAvailable()))
 	return m, nil
 }
 
@@ -447,7 +449,7 @@ func shortcutDeleteSession(m *Model) (tea.Model, tea.Cmd) {
 func shortcutForkSession(m *Model) (tea.Model, tea.Cmd) {
 	sess := m.sidebar.SelectedSession()
 	displayName := ui.SessionDisplayName(sess.Branch, sess.Name)
-	m.modal.Show(ui.NewForkSessionState(displayName, sess.ID, sess.RepoPath))
+	m.modal.Show(ui.NewForkSessionState(displayName, sess.ID, sess.RepoPath, sess.Containerized, process.ContainersSupported(), claude.ContainerAuthAvailable()))
 	return m, nil
 }
 
@@ -881,7 +883,7 @@ func shortcutWorkspaces(m *Model) (tea.Model, tea.Cmd) {
 
 func shortcutBroadcast(m *Model) (tea.Model, tea.Cmd) {
 	repos := m.config.GetRepos()
-	m.modal.Show(ui.NewBroadcastState(repos))
+	m.modal.Show(ui.NewBroadcastState(repos, process.ContainersSupported(), claude.ContainerAuthAvailable()))
 	return m, nil
 }
 

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -215,6 +215,10 @@ type Runner struct {
 
 	// External MCP servers to include in config
 	mcpServers []MCPServer
+
+	// Container mode: when true, skip MCP and run inside a container
+	containerized  bool
+	containerImage string
 }
 
 // New creates a new Claude runner for a session
@@ -301,6 +305,16 @@ func (r *Runner) SetForkFromSession(parentSessionID string) {
 	defer r.mu.Unlock()
 	r.forkFromSessionID = parentSessionID
 	r.log.Debug("set fork from session", "parentSessionID", parentSessionID)
+}
+
+// SetContainerized configures the runner to run inside a container.
+// When containerized, the MCP permission system is skipped entirely.
+func (r *Runner) SetContainerized(containerized bool, image string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.containerized = containerized
+	r.containerImage = image
+	r.log.Debug("set containerized mode", "containerized", containerized, "image", image)
 }
 
 // PermissionRequestChan returns the channel for receiving permission requests.
@@ -556,6 +570,8 @@ func (r *Runner) ensureProcessRunning() error {
 		AllowedTools:      make([]string, len(r.allowedTools)),
 		MCPConfigPath:     r.mcpConfigPath,
 		ForkFromSessionID: r.forkFromSessionID,
+		Containerized:     r.containerized,
+		ContainerImage:    r.containerImage,
 	}
 	copy(config.AllowedTools, r.allowedTools)
 
@@ -1106,6 +1122,12 @@ func (r *Runner) Send(cmdCtx context.Context, prompt string) <-chan ResponseChun
 func (r *Runner) SendContent(cmdCtx context.Context, content []ContentBlock) <-chan ResponseChunk {
 	ch := make(chan ResponseChunk, 100) // Buffered to avoid blocking response reader
 
+	// Read container mode flag under lock before starting the goroutine to
+	// avoid a data race (containerized is set once during init via SetContainerized)
+	r.mu.RLock()
+	isContainerized := r.containerized
+	r.mu.RUnlock()
+
 	go func() {
 		sendStartTime := time.Now()
 
@@ -1123,10 +1145,13 @@ func (r *Runner) SendContent(cmdCtx context.Context, content []ContentBlock) <-c
 		r.mu.Unlock()
 
 		// Ensure MCP server is running (persistent across Send calls)
-		if err := r.ensureServerRunning(); err != nil {
-			ch <- ResponseChunk{Error: err, Done: true}
-			close(ch)
-			return
+		// Skip for containerized sessions — the container IS the sandbox
+		if !isContainerized {
+			if err := r.ensureServerRunning(); err != nil {
+				ch <- ResponseChunk{Error: err, Done: true}
+				close(ch)
+				return
+			}
 		}
 
 		// Set up the response channel for routing BEFORE starting the process.
@@ -1258,23 +1283,26 @@ func (r *Runner) Stop() {
 		// PermissionRequestChan() and QuestionRequestChan() check this flag
 		r.stopped = true
 
-		// Close socket server if running
-		if r.socketServer != nil {
-			r.log.Debug("closing persistent socket server")
-			r.socketServer.Close()
-			r.socketServer = nil
-		}
-
-		// Remove MCP config file and log any errors
-		if r.mcpConfigPath != "" {
-			r.log.Debug("removing MCP config file", "path", r.mcpConfigPath)
-			if err := os.Remove(r.mcpConfigPath); err != nil && !os.IsNotExist(err) {
-				r.log.Warn("failed to remove MCP config file", "path", r.mcpConfigPath, "error", err)
+		// Skip MCP cleanup for containerized sessions — no socket server or MCP config
+		if !r.containerized {
+			// Close socket server if running
+			if r.socketServer != nil {
+				r.log.Debug("closing persistent socket server")
+				r.socketServer.Close()
+				r.socketServer = nil
 			}
-			r.mcpConfigPath = ""
-		}
 
-		r.serverRunning = false
+			// Remove MCP config file and log any errors
+			if r.mcpConfigPath != "" {
+				r.log.Debug("removing MCP config file", "path", r.mcpConfigPath)
+				if err := os.Remove(r.mcpConfigPath); err != nil && !os.IsNotExist(err) {
+					r.log.Warn("failed to remove MCP config file", "path", r.mcpConfigPath, "error", err)
+				}
+				r.mcpConfigPath = ""
+			}
+
+			r.serverRunning = false
+		}
 
 		// Close MCP channels to unblock any waiting goroutines
 		if r.mcp != nil {

--- a/internal/claude/mock_runner.go
+++ b/internal/claude/mock_runner.go
@@ -258,6 +258,12 @@ func (m *MockRunner) SetForkFromSession(parentSessionID string) {
 	// No-op for mock
 }
 
+// SetContainerized implements RunnerInterface.
+// In mock, this is a no-op since we don't spawn real processes.
+func (m *MockRunner) SetContainerized(containerized bool, image string) {
+	// No-op for mock
+}
+
 // PermissionRequestChan implements RunnerInterface.
 func (m *MockRunner) PermissionRequestChan() <-chan mcp.PermissionRequest {
 	m.mu.RLock()

--- a/internal/claude/runner_interface.go
+++ b/internal/claude/runner_interface.go
@@ -26,6 +26,7 @@ type RunnerInterface interface {
 	AddAllowedTool(tool string)
 	SetMCPServers(servers []MCPServer)
 	SetForkFromSession(parentSessionID string)
+	SetContainerized(containerized bool, image string)
 
 	// Permission/Question/Plan channels
 	PermissionRequestChan() <-chan mcp.PermissionRequest

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,8 @@ type Config struct {
 	AllowedTools      []string               `json:"allowed_tools,omitempty"`       // Global allowed tools
 	RepoAllowedTools  map[string][]string    `json:"repo_allowed_tools,omitempty"`  // Per-repo allowed tools
 	RepoSquashOnMerge map[string]bool        `json:"repo_squash_on_merge,omitempty"` // Per-repo squash-on-merge setting
-	RepoAsanaProject  map[string]string      `json:"repo_asana_project,omitempty"`  // Per-repo Asana project GID mapping
+	RepoAsanaProject   map[string]string      `json:"repo_asana_project,omitempty"`   // Per-repo Asana project GID mapping
+	ContainerImage     string                 `json:"container_image,omitempty"`      // Container image for containerized sessions
 
 	WelcomeShown         bool   `json:"welcome_shown,omitempty"`         // Whether welcome modal has been shown
 	LastSeenVersion      string `json:"last_seen_version,omitempty"`     // Last version user has seen changelog for
@@ -404,6 +405,25 @@ func (c *Config) SetAsanaProject(repoPath, projectGID string) {
 // HasAsanaProject returns true if the repo has an Asana project configured
 func (c *Config) HasAsanaProject(repoPath string) bool {
 	return c.GetAsanaProject(repoPath) != ""
+}
+
+
+
+// GetContainerImage returns the container image name, defaulting to "plural-claude"
+func (c *Config) GetContainerImage() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.ContainerImage == "" {
+		return "plural-claude"
+	}
+	return c.ContainerImage
+}
+
+// SetContainerImage sets the container image name
+func (c *Config) SetContainerImage(image string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ContainerImage = image
 }
 
 // GetWorkspaces returns a copy of the workspaces slice

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -33,6 +33,7 @@ type Session struct {
 	IssueRef         *IssueRef `json:"issue_ref,omitempty"`          // Generic issue/task reference (GitHub, Asana, etc.)
 	BroadcastGroupID string    `json:"broadcast_group_id,omitempty"` // Links sessions created from the same broadcast
 	WorkspaceID      string    `json:"workspace_id,omitempty"`       // Workspace this session belongs to
+	Containerized    bool      `json:"containerized,omitempty"`      // Whether this session runs inside a container
 }
 
 // GetIssueRef returns the IssueRef for this session, converting from legacy IssueNumber if needed.

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -1,6 +1,8 @@
 package process
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -105,4 +107,90 @@ func TestFindClaudeProcesses(t *testing.T) {
 
 	// Can't assert on count since it depends on system state
 	_ = processes
+}
+
+func TestContainersSupported(t *testing.T) {
+	// ContainersSupported should return a boolean without panicking.
+	// On darwin/arm64 it returns true; on all other platforms it returns false.
+	result := ContainersSupported()
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		if !result {
+			t.Error("Expected ContainersSupported() to return true on darwin/arm64")
+		}
+	} else {
+		if result {
+			t.Error("Expected ContainersSupported() to return false on non-darwin/arm64")
+		}
+	}
+}
+
+func TestContainerImageExists_NoContainerCLI(t *testing.T) {
+	// With container CLI unavailable, should return false
+	t.Setenv("PATH", "/nonexistent")
+
+	if ContainerImageExists("plural-claude") {
+		t.Error("Expected false when container CLI not found")
+	}
+}
+
+func TestOrphanedContainer_Fields(t *testing.T) {
+	c := OrphanedContainer{
+		Name: "plural-abc123",
+	}
+
+	if c.Name != "plural-abc123" {
+		t.Errorf("Expected Name 'plural-abc123', got %q", c.Name)
+	}
+}
+
+func TestExtractSessionIDFromContainerName(t *testing.T) {
+	tests := []struct {
+		name      string
+		container string
+		wantID    string
+	}{
+		{
+			name:      "standard plural prefix",
+			container: "plural-abc123",
+			wantID:    "abc123",
+		},
+		{
+			name:      "uuid session ID",
+			container: "plural-550e8400-e29b-41d4-a716-446655440000",
+			wantID:    "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:      "minimal name",
+			container: "plural-x",
+			wantID:    "x",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strings.TrimPrefix(tt.container, "plural-")
+			if got != tt.wantID {
+				t.Errorf("TrimPrefix(%q, 'plural-') = %q, want %q", tt.container, got, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestFindOrphanedContainers_NoContainerCLI(t *testing.T) {
+	// Set PATH to empty to ensure container CLI is not found
+	// t.Setenv automatically restores the original value after the test
+	t.Setenv("PATH", "/nonexistent")
+
+	knownSessions := map[string]bool{
+		"session-1": true,
+	}
+
+	containers, err := FindOrphanedContainers(knownSessions)
+	if err != nil {
+		t.Fatalf("Expected no error when container CLI not found, got: %v", err)
+	}
+
+	if len(containers) != 0 {
+		t.Errorf("Expected empty list when container CLI not found, got %d containers", len(containers))
+	}
 }

--- a/internal/ui/header.go
+++ b/internal/ui/header.go
@@ -16,12 +16,13 @@ type DiffStats struct {
 
 // Header represents the top header bar
 type Header struct {
-	width         int
-	sessionName   string
-	baseBranch    string
-	diffStats     *DiffStats
-	previewActive bool
-	workspaceName string
+	width           int
+	sessionName     string
+	baseBranch      string
+	diffStats       *DiffStats
+	previewActive   bool
+	containerActive bool
+	workspaceName   string
 }
 
 // NewHeader creates a new header
@@ -54,6 +55,11 @@ func (h *Header) SetPreviewActive(active bool) {
 	h.previewActive = active
 }
 
+// SetContainerActive sets whether the current session is containerized
+func (h *Header) SetContainerActive(active bool) {
+	h.containerActive = active
+}
+
 // SetWorkspaceName sets the workspace name to display
 func (h *Header) SetWorkspaceName(name string) {
 	h.workspaceName = name
@@ -63,7 +69,7 @@ func (h *Header) SetWorkspaceName(name string) {
 type headerRegion struct {
 	start int
 	end   int
-	style string // "normal", "muted", "added", "deleted", "preview"
+	style string // "normal", "muted", "added", "deleted", "preview", "container"
 }
 
 // View renders the header
@@ -79,6 +85,14 @@ func (h *Header) View() string {
 	var regions []headerRegion
 
 	if h.sessionName != "" {
+		// Add container indicator if active
+		if h.containerActive {
+			containerStart := len(rightText)
+			rightText += "[CONTAINER] "
+			containerEnd := len(rightText)
+			regions = append(regions, headerRegion{start: containerStart, end: containerEnd, style: "container"})
+		}
+
 		// Add preview indicator if active
 		if h.previewActive {
 			previewStart := len(rightText)
@@ -169,7 +183,8 @@ func (h *Header) renderGradient(content string, regions []headerRegion) string {
 	mutedColor := lipgloss.Color(theme.TextMuted)
 	addedColor := lipgloss.Color(theme.DiffAdded)
 	deletedColor := lipgloss.Color(theme.DiffRemoved)
-	previewColor := lipgloss.Color(theme.Warning) // Use warning color (amber/yellow) for preview indicator
+	previewColor := lipgloss.Color(theme.Warning)   // Use warning color (amber/yellow) for preview indicator
+	containerColor := lipgloss.Color(theme.Success) // Use success color (green) for container indicator
 
 	// Helper to get the style for a given position
 	getStyleForPos := func(pos int) string {
@@ -212,6 +227,8 @@ func (h *Header) renderGradient(content string, regions []headerRegion) string {
 			style = style.Foreground(deletedColor)
 		case "preview":
 			style = style.Foreground(previewColor).Bold(true)
+		case "container":
+			style = style.Foreground(containerColor).Bold(true)
 		default:
 			style = style.Foreground(textColor)
 		}

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -59,6 +59,7 @@ type (
 	NewWorkspaceState        = modals.NewWorkspaceState
 	BulkActionState          = modals.BulkActionState
 	BulkAction               = modals.BulkAction
+	ContainerBuildState      = modals.ContainerBuildState
 )
 
 // Re-export broadcast action constants
@@ -107,6 +108,7 @@ var (
 	NewWorkspaceListState      = modals.NewWorkspaceListState
 	NewNewWorkspaceState       = modals.NewNewWorkspaceState
 	NewRenameWorkspaceState    = modals.NewRenameWorkspaceState
+	NewContainerBuildState     = modals.NewContainerBuildState
 	NewBulkActionState         = modals.NewBulkActionState
 	SessionDisplayName             = modals.SessionDisplayName
 	TruncatePath                   = modals.TruncatePath

--- a/internal/ui/modal_test.go
+++ b/internal/ui/modal_test.go
@@ -182,7 +182,7 @@ func TestAddRepoState_Help(t *testing.T) {
 
 func TestNewNewSessionState(t *testing.T) {
 	repos := []string{"/repo1", "/repo2"}
-	state := NewNewSessionState(repos)
+	state := NewNewSessionState(repos, false, false)
 
 	if len(state.RepoOptions) != 2 {
 		t.Errorf("Expected 2 repos, got %d", len(state.RepoOptions))
@@ -203,7 +203,7 @@ func TestNewNewSessionState(t *testing.T) {
 
 func TestNewSessionState_GetSelectedRepo(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3"}
-	state := NewNewSessionState(repos)
+	state := NewNewSessionState(repos, false, false)
 
 	// First repo selected
 	if state.GetSelectedRepo() != "/repo1" {
@@ -217,13 +217,13 @@ func TestNewSessionState_GetSelectedRepo(t *testing.T) {
 	}
 
 	// Empty repos
-	state = NewNewSessionState([]string{})
+	state = NewNewSessionState([]string{}, false, false)
 	if state.GetSelectedRepo() != "" {
 		t.Errorf("Expected empty string for no repos, got %q", state.GetSelectedRepo())
 	}
 
 	// Out of bounds index
-	state = NewNewSessionState(repos)
+	state = NewNewSessionState(repos, false, false)
 	state.RepoIndex = 10
 	if state.GetSelectedRepo() != "" {
 		t.Errorf("Expected empty string for out of bounds, got %q", state.GetSelectedRepo())
@@ -231,7 +231,7 @@ func TestNewSessionState_GetSelectedRepo(t *testing.T) {
 }
 
 func TestNewSessionState_GetBranchName(t *testing.T) {
-	state := NewNewSessionState([]string{"/repo"})
+	state := NewNewSessionState([]string{"/repo"}, false, false)
 
 	// Initially empty
 	if state.GetBranchName() != "" {
@@ -247,14 +247,14 @@ func TestNewSessionState_GetBranchName(t *testing.T) {
 
 func TestNewSessionState_Render(t *testing.T) {
 	// With repos
-	state := NewNewSessionState([]string{"/repo1", "/repo2"})
+	state := NewNewSessionState([]string{"/repo1", "/repo2"}, false, false)
 	render := state.Render()
 	if render == "" {
 		t.Error("Render should not be empty")
 	}
 
 	// Without repos
-	state = NewNewSessionState([]string{})
+	state = NewNewSessionState([]string{}, false, false)
 	render = state.Render()
 	if render == "" {
 		t.Error("Render without repos should not be empty")
@@ -263,7 +263,7 @@ func TestNewSessionState_Render(t *testing.T) {
 
 func TestNewSessionState_Help(t *testing.T) {
 	// With repos, focused on repo list - should show add and delete hints
-	state := NewNewSessionState([]string{"/repo1", "/repo2"})
+	state := NewNewSessionState([]string{"/repo1", "/repo2"}, false, false)
 	state.Focus = 0
 	help := state.Help()
 	if help != "up/down: select  Tab: next field  a: add repo  d: delete repo  Enter: create" {
@@ -271,7 +271,7 @@ func TestNewSessionState_Help(t *testing.T) {
 	}
 
 	// Without repos, focused on repo list - should show add hint
-	state = NewNewSessionState([]string{})
+	state = NewNewSessionState([]string{}, false, false)
 	state.Focus = 0
 	help = state.Help()
 	if help != "a: add repo  Esc: cancel" {
@@ -279,7 +279,7 @@ func TestNewSessionState_Help(t *testing.T) {
 	}
 
 	// With repos, focused on base selection - should not show delete hint
-	state = NewNewSessionState([]string{"/repo1"})
+	state = NewNewSessionState([]string{"/repo1"}, false, false)
 	state.Focus = 1
 	help = state.Help()
 	if help != "up/down: select  Tab: next field  Enter: create" {
@@ -287,7 +287,7 @@ func TestNewSessionState_Help(t *testing.T) {
 	}
 
 	// With repos, focused on branch input - should not show delete hint
-	state = NewNewSessionState([]string{"/repo1"})
+	state = NewNewSessionState([]string{"/repo1"}, false, false)
 	state.Focus = 2
 	help = state.Help()
 	if help != "up/down: select  Tab: next field  Enter: create" {

--- a/internal/ui/modals/broadcast_test.go
+++ b/internal/ui/modals/broadcast_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNewBroadcastState(t *testing.T) {
 	repos := []string{"/path/to/repo1", "/path/to/repo2", "/another/repo3"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Check initial state
 	if len(state.Repos) != 3 {
@@ -44,14 +44,14 @@ func TestNewBroadcastState(t *testing.T) {
 }
 
 func TestBroadcastState_Title(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 	if state.Title() != "Broadcast to Repositories" {
 		t.Errorf("unexpected title: %s", state.Title())
 	}
 }
 
 func TestBroadcastState_Help(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 
 	// Help when focused on repos
 	state.Focus = 0
@@ -77,7 +77,7 @@ func TestBroadcastState_Help(t *testing.T) {
 
 func TestBroadcastState_ToggleSelection(t *testing.T) {
 	repos := []string{"/repo1", "/repo2"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Check initial state
 	if state.Repos[0].Selected {
@@ -99,7 +99,7 @@ func TestBroadcastState_ToggleSelection(t *testing.T) {
 
 func TestBroadcastState_SelectAll(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Manually select all (simulating 'a' key)
 	for i := range state.Repos {
@@ -119,7 +119,7 @@ func TestBroadcastState_SelectAll(t *testing.T) {
 
 func TestBroadcastState_SelectNone(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Select all first
 	for i := range state.Repos {
@@ -143,7 +143,7 @@ func TestBroadcastState_SelectNone(t *testing.T) {
 }
 
 func TestBroadcastState_FocusToggle(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 
 	// Initial focus is on repos (0)
 	if state.Focus != 0 {
@@ -171,7 +171,7 @@ func TestBroadcastState_FocusToggle(t *testing.T) {
 
 func TestBroadcastState_GetSelectedRepos(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Select first and third
 	state.Repos[0].Selected = true
@@ -193,7 +193,7 @@ func TestBroadcastState_GetSelectedRepos(t *testing.T) {
 }
 
 func TestBroadcastState_GetName(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 
 	// Initial name is empty
 	if state.GetName() != "" {
@@ -209,7 +209,7 @@ func TestBroadcastState_GetName(t *testing.T) {
 }
 
 func TestBroadcastState_GetPrompt(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 
 	// Initial prompt is empty
 	if state.GetPrompt() != "" {
@@ -228,7 +228,7 @@ func TestBroadcastState_Render(t *testing.T) {
 	initTestStyles()
 
 	repos := []string{"/repo1", "/repo2"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Select first repo
 	state.Repos[0].Selected = true
@@ -255,7 +255,7 @@ func TestBroadcastState_Render(t *testing.T) {
 }
 
 func TestBroadcastState_EmptyRepos(t *testing.T) {
-	state := NewBroadcastState([]string{})
+	state := NewBroadcastState([]string{}, false, false)
 
 	if len(state.Repos) != 0 {
 		t.Errorf("expected 0 repos, got %d", len(state.Repos))
@@ -279,7 +279,7 @@ func TestBroadcastState_ScrollOffset(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		repos[i] = "/repo" + string(rune('0'+i))
 	}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Initial scroll offset is 0
 	if state.ScrollOffset != 0 {
@@ -301,7 +301,7 @@ func TestBroadcastState_ScrollOffset(t *testing.T) {
 
 func TestBroadcastState_Navigation(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Test down navigation
 	state.SelectedIndex = 1
@@ -329,7 +329,7 @@ func TestBroadcastState_Navigation(t *testing.T) {
 
 func TestBroadcastState_GetSelectedCount(t *testing.T) {
 	repos := []string{"/repo1", "/repo2", "/repo3", "/repo4"}
-	state := NewBroadcastState(repos)
+	state := NewBroadcastState(repos, false, false)
 
 	// Initially zero
 	if state.GetSelectedCount() != 0 {
@@ -355,7 +355,7 @@ func TestBroadcastState_GetSelectedCount(t *testing.T) {
 }
 
 func TestBroadcastState_ModalStateInterface(t *testing.T) {
-	state := NewBroadcastState([]string{"/repo"})
+	state := NewBroadcastState([]string{"/repo"}, false, false)
 
 	// Verify it implements ModalState interface
 	var _ ModalState = state

--- a/internal/ui/modals/config.go
+++ b/internal/ui/modals/config.go
@@ -416,7 +416,7 @@ func (s *SettingsState) Render() string {
 			Render("Links this repo to an Asana project for task import")
 
 		asanaInputStyle := lipgloss.NewStyle()
-		if s.Focus == 3 {
+		if s.Focus == s.asanaFocusIndex() {
 			asanaInputStyle = asanaInputStyle.BorderLeft(true).BorderStyle(lipgloss.NormalBorder()).BorderForeground(ColorPrimary).PaddingLeft(1)
 		} else {
 			asanaInputStyle = asanaInputStyle.PaddingLeft(2)
@@ -435,12 +435,21 @@ func (s *SettingsState) Render() string {
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
-func (s *SettingsState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
-	// Determine number of focusable fields (4 if repo selected, 2 otherwise)
-	numFields := 2
-	if s.RepoPath != "" {
-		numFields = 4
+// numFields returns the number of focusable fields in the settings modal.
+func (s *SettingsState) numFields() int {
+	if s.RepoPath == "" {
+		return 2 // branch prefix, notifications
 	}
+	return 4 // branch prefix, notifications, squash, asana
+}
+
+// asanaFocusIndex returns the focus index for the Asana project field.
+func (s *SettingsState) asanaFocusIndex() int {
+	return 3
+}
+
+func (s *SettingsState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
+	numFields := s.numFields()
 
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
 		switch keyMsg.String() {
@@ -471,7 +480,7 @@ func (s *SettingsState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
 	}
 
 	// Handle text input updates when focused on Asana project GID
-	if s.Focus == 3 {
+	if s.Focus == s.asanaFocusIndex() {
 		var cmd tea.Cmd
 		s.AsanaProjectInput, cmd = s.AsanaProjectInput.Update(msg)
 		return s, cmd
@@ -485,7 +494,7 @@ func (s *SettingsState) updateInputFocus() {
 	if s.Focus == 0 {
 		s.BranchPrefixInput.Focus()
 		s.AsanaProjectInput.Blur()
-	} else if s.Focus == 3 {
+	} else if s.Focus == s.asanaFocusIndex() {
 		s.AsanaProjectInput.Focus()
 		s.BranchPrefixInput.Blur()
 	} else {

--- a/internal/ui/modals/config_test.go
+++ b/internal/ui/modals/config_test.go
@@ -1,0 +1,333 @@
+package modals
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestSettingsState_NumFields_NoRepo(t *testing.T) {
+	s := NewSettingsState("", false, false, "", "")
+	if n := s.numFields(); n != 2 {
+		t.Errorf("Expected 2 fields with no repo, got %d", n)
+	}
+}
+
+func TestSettingsState_NumFields_WithRepo(t *testing.T) {
+	s := NewSettingsState("", false, false, "/some/repo", "")
+	if n := s.numFields(); n != 4 {
+		t.Errorf("Expected 4 fields with repo, got %d", n)
+	}
+}
+
+func TestSettingsState_AsanaFocusIndex(t *testing.T) {
+	s := NewSettingsState("", false, false, "/some/repo", "")
+	if idx := s.asanaFocusIndex(); idx != 3 {
+		t.Errorf("Expected asana focus index 3, got %d", idx)
+	}
+}
+
+func TestSettingsState_TabCycle_WithRepo(t *testing.T) {
+	s := NewSettingsState("", false, false, "/some/repo", "")
+
+	// Start at 0 (branch prefix)
+	if s.Focus != 0 {
+		t.Fatalf("Expected initial focus 0, got %d", s.Focus)
+	}
+
+	// Tab through: 0 -> 1 -> 2 -> 3 -> 0 (4 fields with repo)
+	expectedFoci := []int{1, 2, 3, 0}
+	for i, expected := range expectedFoci {
+		s.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+		if s.Focus != expected {
+			t.Errorf("After tab %d: expected focus %d, got %d", i+1, expected, s.Focus)
+		}
+	}
+}
+
+func TestSettingsState_Render_NoContainerSection(t *testing.T) {
+	// Container settings should no longer appear in settings modal
+	s := NewSettingsState("", false, false, "/some/repo", "")
+	rendered := s.Render()
+
+	if strings.Contains(rendered, "Run sessions in containers") {
+		t.Error("Container checkbox should not appear in settings modal")
+	}
+	if strings.Contains(rendered, "defense in depth") {
+		t.Error("Container warning should not appear in settings modal")
+	}
+}
+
+func TestNewSessionState_ContainerCheckbox_WhenSupported(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, false)
+
+	if s.numFields() != 4 {
+		t.Errorf("Expected 4 fields with containers supported, got %d", s.numFields())
+	}
+
+	// Tab to container checkbox (focus 3)
+	s.Focus = 3
+	s.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if !s.UseContainers {
+		t.Error("Space at focus 3 should toggle container checkbox when supported")
+	}
+
+	// Toggle back
+	s.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if s.UseContainers {
+		t.Error("Space again should toggle container checkbox off")
+	}
+}
+
+func TestNewSessionState_ContainerCheckbox_WhenUnsupported(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, false, false)
+
+	if s.numFields() != 3 {
+		t.Errorf("Expected 3 fields with containers unsupported, got %d", s.numFields())
+	}
+
+	// Container checkbox should not be rendered
+	rendered := s.Render()
+	if strings.Contains(rendered, "Run in container") {
+		t.Error("Container checkbox should not appear when unsupported")
+	}
+}
+
+func TestNewSessionState_ContainerCheckbox_Render(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, false)
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "Run in container") {
+		t.Error("Container checkbox should appear when supported")
+	}
+	if !strings.Contains(rendered, "defense in depth") {
+		t.Error("Container warning should appear when supported")
+	}
+}
+
+func TestNewSessionState_GetUseContainers(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, false)
+
+	if s.GetUseContainers() {
+		t.Error("GetUseContainers should return false initially")
+	}
+
+	s.UseContainers = true
+	if !s.GetUseContainers() {
+		t.Error("GetUseContainers should return true after setting")
+	}
+}
+
+func TestForkSessionState_ContainerCheckbox_WhenSupported(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, true, false)
+
+	if s.numFields() != 3 {
+		t.Errorf("Expected 3 fields with containers supported, got %d", s.numFields())
+	}
+
+	// Tab to container checkbox (focus 2)
+	s.Focus = 2
+	s.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if !s.UseContainers {
+		t.Error("Space at focus 2 should toggle container checkbox when supported")
+	}
+}
+
+func TestForkSessionState_ContainerCheckbox_WhenUnsupported(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, false, false)
+
+	if s.numFields() != 2 {
+		t.Errorf("Expected 2 fields with containers unsupported, got %d", s.numFields())
+	}
+
+	rendered := s.Render()
+	if strings.Contains(rendered, "Run in container") {
+		t.Error("Container checkbox should not appear when unsupported")
+	}
+}
+
+func TestForkSessionState_InheritsParentContainerized(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", true, true, false)
+
+	if !s.UseContainers {
+		t.Error("Fork should default to parent's containerized state (true)")
+	}
+
+	s2 := NewForkSessionState("parent", "parent-id", "/repo", false, true, false)
+	if s2.UseContainers {
+		t.Error("Fork should default to parent's containerized state (false)")
+	}
+}
+
+func TestForkSessionState_ContainerCheckbox_Render(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, true, false)
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "Run in container") {
+		t.Error("Container checkbox should appear when supported")
+	}
+}
+
+func TestForkSessionState_UpDownNavigation_CyclesToContainerCheckbox(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, true, false)
+
+	// Start at focus 0
+	if s.Focus != 0 {
+		t.Fatalf("Expected focus 0, got %d", s.Focus)
+	}
+
+	// Press down should go to focus 1
+	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if s.Focus != 1 {
+		t.Errorf("After Down from 0, expected focus 1, got %d", s.Focus)
+	}
+
+	// Press down should go to focus 2 (container checkbox)
+	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if s.Focus != 2 {
+		t.Errorf("After Down from 1, expected focus 2 (container checkbox), got %d", s.Focus)
+	}
+
+	// Press down should wrap to focus 0
+	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if s.Focus != 0 {
+		t.Errorf("After Down from 2, expected focus 0 (wrap), got %d", s.Focus)
+	}
+
+	// Press up should go to focus 2
+	s.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if s.Focus != 2 {
+		t.Errorf("After Up from 0, expected focus 2 (wrap), got %d", s.Focus)
+	}
+}
+
+func TestForkSessionState_UpDownNavigation_WithoutContainers(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, false, false)
+
+	// Only 2 fields: toggle between 0 and 1
+	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if s.Focus != 1 {
+		t.Errorf("After Down from 0, expected focus 1, got %d", s.Focus)
+	}
+
+	s.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if s.Focus != 0 {
+		t.Errorf("After Down from 1, expected focus 0 (wrap), got %d", s.Focus)
+	}
+}
+
+func TestForkSessionState_HelpText_ContainerFocused(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", false, true, false)
+	s.Focus = 2
+
+	help := s.Help()
+	if !strings.Contains(help, "Space: toggle") {
+		t.Errorf("Help at container focus should mention Space: toggle, got %q", help)
+	}
+}
+
+func TestBroadcastState_ContainerCheckbox_WhenSupported(t *testing.T) {
+	s := NewBroadcastState([]string{"/repo"}, true, false)
+
+	if !s.ContainersSupported {
+		t.Error("ContainersSupported should be true")
+	}
+
+	// Tab to container checkbox (focus 3)
+	s.Focus = 3
+	s.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if !s.UseContainers {
+		t.Error("Space at focus 3 should toggle container checkbox")
+	}
+
+	if !s.GetUseContainers() {
+		t.Error("GetUseContainers should return true after toggle")
+	}
+}
+
+func TestBroadcastState_ContainerCheckbox_WhenUnsupported(t *testing.T) {
+	s := NewBroadcastState([]string{"/repo"}, false, false)
+
+	rendered := s.Render()
+	if strings.Contains(rendered, "Run in containers") {
+		t.Error("Container checkbox should not appear when unsupported")
+	}
+}
+
+func TestBroadcastState_ContainerCheckbox_Render(t *testing.T) {
+	s := NewBroadcastState([]string{"/repo"}, true, false)
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "Run in containers") {
+		t.Error("Container checkbox should appear when supported")
+	}
+}
+
+func TestNewSessionState_AuthWarning_WhenNoAuth(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, false)
+	s.UseContainers = true
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should appear when containers checked and no auth")
+	}
+}
+
+func TestNewSessionState_AuthWarning_WhenAuthAvailable(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, true)
+	s.UseContainers = true
+	rendered := s.Render()
+
+	if strings.Contains(rendered, "Requires ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should not appear when auth is available")
+	}
+}
+
+func TestNewSessionState_AuthWarning_WhenContainersNotChecked(t *testing.T) {
+	s := NewNewSessionState([]string{"/repo"}, true, false)
+	// UseContainers is false by default
+	rendered := s.Render()
+
+	if strings.Contains(rendered, "Requires ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should not appear when containers not checked")
+	}
+}
+
+func TestForkSessionState_AuthWarning_WhenNoAuth(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", true, true, false)
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should appear when containers checked and no auth (inherited from parent)")
+	}
+}
+
+func TestForkSessionState_AuthWarning_WhenAuthAvailable(t *testing.T) {
+	s := NewForkSessionState("parent", "parent-id", "/repo", true, true, true)
+	rendered := s.Render()
+
+	if strings.Contains(rendered, "Requires ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should not appear when auth is available")
+	}
+}
+
+func TestBroadcastState_AuthWarning_WhenNoAuth(t *testing.T) {
+	s := NewBroadcastState([]string{"/repo"}, true, false)
+	s.UseContainers = true
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should appear when containers checked and no auth")
+	}
+}
+
+func TestBroadcastState_AuthWarning_WhenAuthAvailable(t *testing.T) {
+	s := NewBroadcastState([]string{"/repo"}, true, true)
+	s.UseContainers = true
+	rendered := s.Render()
+
+	if strings.Contains(rendered, "Requires ANTHROPIC_API_KEY") {
+		t.Error("Auth warning should not appear when auth is available")
+	}
+}

--- a/internal/ui/modals/container_build.go
+++ b/internal/ui/modals/container_build.go
@@ -1,0 +1,106 @@
+package modals
+
+import (
+	"regexp"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// validContainerImage matches valid container image names: lowercase alphanumeric,
+// dots, hyphens, underscores, slashes (for namespaced images), and colons (for tags).
+var validContainerImage = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-/:]*$`)
+
+// ContainerBuildState shows the user how to build the container image.
+type ContainerBuildState struct {
+	Image  string // Image name (e.g., "plural-claude")
+	Copied bool   // Whether the command was copied to clipboard
+}
+
+func (*ContainerBuildState) modalState() {}
+
+func (s *ContainerBuildState) Title() string { return "Container Image Not Found" }
+
+func (s *ContainerBuildState) Help() string {
+	if s.Copied {
+		return "Copied! Press Esc to dismiss"
+	}
+	return "Enter: copy to clipboard  Esc: dismiss"
+}
+
+func (s *ContainerBuildState) Render() string {
+	title := ModalTitleStyle.Render(s.Title())
+
+	message := lipgloss.NewStyle().
+		Foreground(ColorText).
+		Width(55).
+		MarginBottom(1).
+		Render("The container image '" + s.Image + "' was not found. Run these commands to set up containers:")
+
+	cmdStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorPrimary).
+		Background(lipgloss.Color("#1a1a2e")).
+		Padding(0, 1)
+
+	stepLabelStyle := lipgloss.NewStyle().
+		Foreground(ColorTextMuted).
+		MarginTop(1)
+
+	step1Label := stepLabelStyle.Render("1. Install Apple's container CLI:")
+	step1Cmd := cmdStyle.Render("brew install container")
+
+	step2Label := stepLabelStyle.Render("2. Start the container system service:")
+	step2Cmd := cmdStyle.Render("container system start")
+
+	step3Label := stepLabelStyle.Render("3. Build the image (from Plural repo root):")
+	step3Cmd := cmdStyle.MarginBottom(1).Render("container build -t " + s.Image + " .")
+
+	var statusView string
+	if s.Copied {
+		statusView = lipgloss.NewStyle().
+			Foreground(ColorPrimary).
+			Bold(true).
+			Render("Copied to clipboard!")
+	}
+
+	help := ModalHelpStyle.Render(s.Help())
+
+	parts := []string{title, message, step1Label, step1Cmd, step2Label, step2Cmd, step3Label, step3Cmd}
+	if statusView != "" {
+		parts = append(parts, statusView)
+	}
+	parts = append(parts, help)
+
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (s *ContainerBuildState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
+	return s, nil
+}
+
+// GetBuildCommand returns the setup commands for clipboard copying.
+// The image name is validated before inclusion to prevent shell injection.
+func (s *ContainerBuildState) GetBuildCommand() string {
+	image := s.Image
+	if !validContainerImage.MatchString(image) {
+		image = "plural-claude" // fall back to default for invalid names
+	}
+	return "brew install container && container system start && container build -t " + image + " ."
+}
+
+// ValidateContainerImage checks if the given image name is safe.
+func ValidateContainerImage(image string) bool {
+	return validContainerImage.MatchString(image)
+}
+
+// NewContainerBuildState creates a new ContainerBuildState.
+// Invalid image names are replaced with the default to prevent shell injection.
+func NewContainerBuildState(image string) *ContainerBuildState {
+	if !validContainerImage.MatchString(image) {
+		image = "plural-claude"
+	}
+	return &ContainerBuildState{
+		Image: image,
+	}
+}

--- a/internal/ui/modals/container_build_test.go
+++ b/internal/ui/modals/container_build_test.go
@@ -1,0 +1,143 @@
+package modals
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContainerBuildState_Title(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	if s.Title() != "Container Image Not Found" {
+		t.Errorf("Expected title 'Container Image Not Found', got %q", s.Title())
+	}
+}
+
+func TestContainerBuildState_GetBuildCommand(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	expected := "brew install container && container system start && container build -t plural-claude ."
+	if cmd := s.GetBuildCommand(); cmd != expected {
+		t.Errorf("Expected build command %q, got %q", expected, cmd)
+	}
+}
+
+func TestContainerBuildState_GetBuildCommand_CustomImage(t *testing.T) {
+	s := NewContainerBuildState("my-image")
+	expected := "brew install container && container system start && container build -t my-image ."
+	if cmd := s.GetBuildCommand(); cmd != expected {
+		t.Errorf("Expected build command %q, got %q", expected, cmd)
+	}
+}
+
+func TestContainerBuildState_Render_ShowsBuildCommand(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "container build -t plural-claude .") {
+		t.Error("Rendered output should contain the build command")
+	}
+}
+
+func TestContainerBuildState_Render_ShowsBrewInstall(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "brew install container") {
+		t.Error("Rendered output should contain the brew install command")
+	}
+}
+
+func TestContainerBuildState_Render_ShowsSystemStart(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "container system start") {
+		t.Error("Rendered output should contain the system start command")
+	}
+}
+
+func TestContainerBuildState_Render_ShowsImageName(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "plural-claude") {
+		t.Error("Rendered output should contain the image name")
+	}
+}
+
+func TestContainerBuildState_Help_BeforeCopy(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	help := s.Help()
+
+	if !strings.Contains(help, "copy to clipboard") {
+		t.Errorf("Help before copy should mention clipboard, got %q", help)
+	}
+}
+
+func TestContainerBuildState_Help_AfterCopy(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	s.Copied = true
+	help := s.Help()
+
+	if !strings.Contains(help, "Copied") {
+		t.Errorf("Help after copy should say Copied, got %q", help)
+	}
+}
+
+func TestContainerBuildState_Render_ShowsCopiedMessage(t *testing.T) {
+	s := NewContainerBuildState("plural-claude")
+	s.Copied = true
+	rendered := s.Render()
+
+	if !strings.Contains(rendered, "Copied to clipboard") {
+		t.Error("Rendered output should show 'Copied to clipboard' after copy")
+	}
+}
+
+func TestValidateContainerImage(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		valid bool
+	}{
+		{"valid simple name", "plural-claude", true},
+		{"valid with dots", "my.image.name", true},
+		{"valid with underscores", "my_image", true},
+		{"valid with tag", "plural-claude:latest", true},
+		{"valid with namespace", "registry/image:v1", true},
+		{"valid uppercase", "MyImage", true},
+		{"empty string", "", false},
+		{"shell injection semicolon", "image; rm -rf /", false},
+		{"shell injection backtick", "image`whoami`", false},
+		{"shell injection dollar", "image$(whoami)", false},
+		{"shell injection pipe", "image|cat /etc/passwd", false},
+		{"starts with hyphen", "-image", false},
+		{"starts with dot", ".image", false},
+		{"spaces", "my image", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateContainerImage(tt.image); got != tt.valid {
+				t.Errorf("ValidateContainerImage(%q) = %v, want %v", tt.image, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestNewContainerBuildState_SanitizesInvalidImage(t *testing.T) {
+	s := NewContainerBuildState("; rm -rf /")
+	if s.Image != "plural-claude" {
+		t.Errorf("Invalid image name should be replaced with default, got %q", s.Image)
+	}
+}
+
+func TestGetBuildCommand_SanitizesInvalidImage(t *testing.T) {
+	s := &ContainerBuildState{Image: "; rm -rf /"}
+	cmd := s.GetBuildCommand()
+	if strings.Contains(cmd, "rm -rf") {
+		t.Error("GetBuildCommand should not include shell injection in output")
+	}
+	if !strings.Contains(cmd, "plural-claude") {
+		t.Error("GetBuildCommand should fall back to default image for invalid names")
+	}
+}


### PR DESCRIPTION
Implements container mode for Claude sessions using Apple containers with --dangerously-skip-permissions. The container IS the sandbox, eliminating the MCP permission system for containerized sessions.

Key features:
- Container checkbox in session creation modals (Apple Silicon only)
- Authentication via ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
- Container orphan cleanup integrated into 'plural clean'
- ProcessManager handles containerized vs non-containerized execution
- Worktree mounting and credential injection
- [CONTAINER] indicator in UI header
- Security warning that containers are defense-in-depth, not complete boundary
- Build instructions modal for setting up container image

Technical details:
- Session.Containerized flag set at creation, immutable, inherited by forks
- ProcessManager.BuildCommandArgs() replaces MCP with --dangerously-skip-permissions
- ContainerAuthAvailable() checks for API key, OAuth token, or keychain
- buildContainerRunArgs() constructs container run with proper mounts
- FindOrphanedContainers() integrated into cleanup workflow
- ContainersSupported() gates feature to darwin/arm64 only

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

remove todo