### PR TITLE
Fix welcome screen keyboard shortcut for adding repository

### DIFF
--- a/internal/ui/modals/config.go
+++ b/internal/ui/modals/config.go
@@ -42,7 +42,7 @@ func (s *WelcomeState) Render() string {
 
 	shortcuts := lipgloss.NewStyle().
 		Foreground(ColorText).
-		Render("  r   Add a git repository\n  n   Create a new session\n  Tab Switch between sidebar and chat")
+		Render("  a   Add a git repository\n  n   Create a new session\n  Tab Switch between sidebar and chat")
 
 	issuesLabel := lipgloss.NewStyle().
 		Foreground(ColorTextMuted).


### PR DESCRIPTION
## Summary
Corrects the keyboard shortcut displayed on the welcome screen for adding a git repository from `r` to `a`.

## Changes
- Updated welcome screen shortcut display in `internal/ui/modals/config.go`
- Changed "r Add a git repository" to "a Add a git repository" to match the actual keybinding

## Test plan
- Run `./plural` with no configured repositories
- Verify the welcome screen displays "a Add a git repository"
- Press `a` to confirm the shortcut works as displayed