### PR TITLE
Change default theme to Tokyo Night

### DIFF
--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -100,7 +100,7 @@ const (
 )
 
 // DefaultTheme is the default theme name
-const DefaultTheme = ThemeDarkPurple
+const DefaultTheme = ThemeTokyoNight
 
 // BuiltinThemes contains all built-in themes
 var BuiltinThemes = map[ThemeName]Theme{


### PR DESCRIPTION
## Summary
Updates the default theme from Dark Purple to Tokyo Night to provide a more modern and popular color scheme out of the box.

## Changes
- Changed `DefaultTheme` constant from `ThemeDarkPurple` to `ThemeTokyoNight` in `internal/ui/theme.go`
- New users will now see Tokyo Night theme on first launch
- Existing users' theme preferences are preserved in their config

## Test plan
- Build and run `./plural` with a fresh config (no `~/.plural/config.json`)
- Verify the TUI launches with Tokyo Night color scheme (dark blue background, cyan accents)
- Verify existing installations retain their selected theme by checking config persistence
- Test theme switching with `t` key to ensure all themes still work correctly