### PR TITLE
Update installation options text to reflect removed Nix/Devbox support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -293,7 +293,7 @@
                 <code><span class="prompt">$</span> brew tap zhubert/tap && brew install plural</code>
             </div>
             <p style="margin-top: 0.75rem; font-size: 0.8rem; color: var(--text-muted);">
-                <a href="https://github.com/zhubert/plural#installation" style="color: var(--text-muted); text-decoration: underline;">Other install options</a> (nix, devbox, go install)
+                <a href="https://github.com/zhubert/plural#installation" style="color: var(--text-muted); text-decoration: underline;">Build from source</a>
             </p>
         </section>
 


### PR DESCRIPTION
## Summary
Updates the landing page to remove references to Nix and Devbox installation methods, which were removed in a previous commit. The link now simply says "Build from source" to accurately reflect the available installation options.

## Changes
- Updated `docs/index.html` installation section link text from "Other install options (nix, devbox, go install)" to "Build from source"
- Maintains the link to the GitHub installation instructions

## Test plan
- Open `docs/index.html` in a browser
- Verify the installation section shows "Build from source" link text
- Verify the link still points to the correct GitHub installation section