### PR TITLE
Fix PR creation to use session base branch instead of main

### DIFF
--- a/internal/app/modal_handlers_git.go
+++ b/internal/app/modal_handlers_git.go
@@ -101,7 +101,7 @@ func (m *Model) handleMergeModal(key string, msg tea.KeyPressMsg, state *ui.Merg
 		case MergeTypePR:
 			log.Info("creating PR (no uncommitted changes)")
 			m.chat.AppendStreaming("Creating PR for " + sess.Branch + "...\n\n")
-			m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, "", sess.GetIssueRef()), cancel, MergeTypePR)
+			m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, sess.BaseBranch, "", sess.GetIssueRef()), cancel, MergeTypePR)
 		case MergeTypePush:
 			log.Info("pushing updates (no uncommitted changes)")
 			m.chat.AppendStreaming("Pushing updates to " + sess.Branch + "...\n\n")
@@ -194,7 +194,7 @@ func (m *Model) handleEditCommitModal(key string, msg tea.KeyPressMsg, state *ui
 		case MergeTypePR:
 			log.Info("creating PR with user-edited commit message")
 			m.chat.AppendStreaming("Creating PR for " + sess.Branch + "...\n\n")
-			m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, commitMsg, sess.GetIssueRef()), cancel, MergeTypePR)
+			m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, sess.BaseBranch, commitMsg, sess.GetIssueRef()), cancel, MergeTypePR)
 		case MergeTypePush:
 			log.Info("pushing updates with user-edited commit message")
 			m.chat.AppendStreaming("Pushing updates to " + sess.Branch + "...\n\n")

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -1013,7 +1013,7 @@ func (m *Model) createPRsForSessions(sessions []config.Session) (tea.Model, tea.
 		sessionLog := logger.WithSession(sess.ID)
 		sessionLog.Info("starting PR creation")
 		mergeCtx, cancel := context.WithCancel(context.Background())
-		m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, "", sess.GetIssueRef()), cancel, MergeTypePR)
+		m.sessionState().StartMerge(sess.ID, m.gitService.CreatePR(mergeCtx, sess.RepoPath, sess.WorkTree, sess.Branch, sess.BaseBranch, "", sess.GetIssueRef()), cancel, MergeTypePR)
 
 		// Add listener for merge result
 		cmds = append(cmds, m.listenForMergeResult(sess.ID))

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -232,7 +232,8 @@ func (s *GitService) AbortMerge(ctx context.Context, repoPath string) error {
 // worktreePath is where Claude made changes - we commit any uncommitted changes first
 // If commitMsg is provided and non-empty, it will be used directly instead of generating one
 // If issueRef is provided, appropriate link text will be added to the PR body based on the source.
-func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branch, commitMsg string, issueRef *config.IssueRef) <-chan Result {
+// baseBranch is the branch this PR should be compared against (typically the session's BaseBranch).
+func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branch, baseBranch, commitMsg string, issueRef *config.IssueRef) <-chan Result {
 	ch := make(chan Result)
 
 	go func() {
@@ -264,7 +265,7 @@ func (s *GitService) CreatePR(ctx context.Context, repoPath, worktreePath, branc
 
 		// Generate PR title and body with Claude
 		ch <- Result{Output: "\nGenerating PR description with Claude...\n"}
-		prTitle, prBody, err := s.GeneratePRTitleAndBodyWithIssueRef(ctx, repoPath, branch, issueRef)
+		prTitle, prBody, err := s.GeneratePRTitleAndBodyWithIssueRef(ctx, repoPath, branch, baseBranch, issueRef)
 		var ghArgs []string
 		if err != nil {
 			log.Warn("Claude PR generation failed, using --fill", "error", err)


### PR DESCRIPTION
## Summary
This PR fixes a bug where pull requests were always compared against the default branch (main) instead of the session's base branch. This caused issues when forking sessions from non-main branches - the PR would incorrectly show all changes from the parent branch instead of just the session's changes.

## Changes
- Updated `CreatePR` to accept a `baseBranch` parameter from the session's `BaseBranch` field
- Modified `GeneratePRTitleAndBodyWithIssueRef` to use the provided base branch when generating commit logs and diffs
- Falls back to default branch when `baseBranch` is empty (preserves backward compatibility)
- Updated all PR creation call sites to pass `sess.BaseBranch`
- Added comprehensive test coverage for base branch handling

## Test plan
- Create a session from main branch, verify PR still compares against main
- Fork a session from a feature branch, verify the forked session's PR only shows changes made in the fork (not parent branch changes)
- Test broadcast PR creation to ensure all sessions use their respective base branches
- Run existing test suite: `go test ./...`