### PR TITLE
Optimize streaming rendering with chunk batching

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -927,6 +927,8 @@ func (m *Model) selectSession(sess *config.Session) {
 	if m.activeSession != nil {
 		previousSessionID = m.activeSession.ID
 		previousInput = m.chat.GetInput()
+		// Flush any buffered streaming content before switching sessions
+		m.chat.FlushStreamingBuffer()
 		previousStreaming = m.chat.GetStreaming()
 	}
 

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -109,6 +109,9 @@ func TestFullFlow_MultipleChunks(t *testing.T) {
 		m = simulateClaudeResponse(m, sessionID, textChunk(chunk))
 	}
 
+	// Flush buffer before verifying (chunks are batched now)
+	m.chat.FlushStreamingBuffer()
+
 	// Verify content accumulated
 	streaming := m.chat.GetStreaming()
 	for _, chunk := range chunks {
@@ -413,6 +416,9 @@ func TestSessionSwitch_PreservesStreamingContent(t *testing.T) {
 
 	// Simulate partial streaming (no done chunk)
 	m = simulateClaudeResponse(m, sessionA, textChunk("Partial response..."))
+
+	// Flush buffer before checking content
+	m.chat.FlushStreamingBuffer()
 
 	// Get streaming content
 	streamingBefore := m.chat.GetStreaming()
@@ -1026,6 +1032,7 @@ func TestGitResult_StreamingOutput(t *testing.T) {
 
 	// Simulate merge output streaming
 	m = simulateMergeResult(m, sessionID, "Checking out main...\n", nil, false, nil, "")
+	m.chat.FlushStreamingBuffer()
 
 	// Verify output is appended to chat
 	streaming := m.chat.GetStreaming()
@@ -1035,6 +1042,7 @@ func TestGitResult_StreamingOutput(t *testing.T) {
 
 	// More output
 	m = simulateMergeResult(m, sessionID, "Merging feature-branch...\n", nil, false, nil, "")
+	m.chat.FlushStreamingBuffer()
 
 	streaming = m.chat.GetStreaming()
 	if !strings.Contains(streaming, "Merging feature-branch") {
@@ -1055,6 +1063,7 @@ func TestGitResult_ErrorHandling(t *testing.T) {
 
 	// Simulate an error
 	m = simulateMergeResult(m, sessionID, "", errors.New("merge failed: branch diverged"), true, nil, "")
+	m.chat.FlushStreamingBuffer()
 
 	// Verify error is shown in chat
 	streaming := m.chat.GetStreaming()

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -987,6 +987,7 @@ func TestChat_Streaming(t *testing.T) {
 
 	// Append streaming content
 	chat.AppendStreaming("Hello")
+	chat.FlushStreamingBuffer()
 	if chat.GetStreaming() != "Hello" {
 		t.Errorf("Expected streaming 'Hello', got %q", chat.GetStreaming())
 	}
@@ -996,6 +997,7 @@ func TestChat_Streaming(t *testing.T) {
 	}
 
 	chat.AppendStreaming(" world")
+	chat.FlushStreamingBuffer()
 	if chat.GetStreaming() != "Hello world" {
 		t.Errorf("Expected 'Hello world', got %q", chat.GetStreaming())
 	}
@@ -1164,6 +1166,7 @@ func TestChat_ToolUseRollupResetOnFinishStreaming(t *testing.T) {
 	chat.AppendStreaming("Merging branch...\n")
 	chat.AppendStreaming("Checking out main...\n")
 	chat.AppendStreaming("Already up to date.\n")
+	chat.FlushStreamingBuffer()
 
 	// The streaming content should NOT have extra newlines inserted
 	streaming := chat.GetStreaming()
@@ -1444,6 +1447,7 @@ func TestChat_ToolUseFlushBlankLineBeforeToolUses(t *testing.T) {
 
 	// Now more text arrives - this triggers flushToolUseRollup
 	chat.AppendStreaming("Found it!")
+	chat.FlushStreamingBuffer()
 
 	streaming := chat.GetStreaming()
 


### PR DESCRIPTION
## Summary
- Buffer streaming chunks and flush periodically (~20 renders/sec) instead of rendering each tiny chunk individually
- Reduces rendering overhead when Claude sends thousands of small text chunks
- Add `FlushStreamingBuffer()` method to explicitly flush buffered content before session switches or completion
- Update integration tests to flush buffer before verifying content

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Integration tests updated to handle buffered chunks
- [x] Manual testing with streaming responses shows smoother rendering
- [x] Session switching properly flushes buffered content

🤖 Generated with [Claude Code](https://claude.com/claude-code)