### PR TITLE
fix: remove unused command batching in focus toggle

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -755,7 +755,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) toggleFocus() tea.Cmd {
-	var cmds []tea.Cmd
 	if m.focus == FocusSidebar {
 		// Only allow switching to chat if there's an active session
 		if m.activeSession == nil {
@@ -768,9 +767,6 @@ func (m *Model) toggleFocus() tea.Cmd {
 		m.focus = FocusSidebar
 		m.sidebar.SetFocused(true)
 		m.chat.SetFocused(false)
-	}
-	if len(cmds) > 0 {
-		return tea.Batch(cmds...)
 	}
 	return nil
 }

--- a/internal/app/focus_test.go
+++ b/internal/app/focus_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// toggleFocus Tests
+// =============================================================================
+
+func TestToggleFocus_SidebarToChat_WithActiveSession(t *testing.T) {
+	cfg := testConfigWithSessions()
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Select the first session to make it active
+	m.activeSession = &cfg.Sessions[0]
+	m.focus = FocusSidebar
+
+	// Toggle focus from sidebar to chat
+	cmd := m.toggleFocus()
+
+	// Verify focus switched to chat
+	if m.focus != FocusChat {
+		t.Errorf("expected focus to be FocusChat, got %v", m.focus)
+	}
+
+	// Verify sidebar is unfocused
+	if m.sidebar.IsFocused() {
+		t.Error("expected sidebar to be unfocused")
+	}
+
+	// Verify chat is focused
+	if !m.chat.IsFocused() {
+		t.Error("expected chat to be focused")
+	}
+
+	// Verify no command is returned (regression test for issue #147)
+	if cmd != nil {
+		t.Errorf("expected nil command, got %v", cmd)
+	}
+}
+
+func TestToggleFocus_SidebarToChat_WithoutActiveSession(t *testing.T) {
+	cfg := testConfig()
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Ensure no active session
+	m.activeSession = nil
+	m.focus = FocusSidebar
+
+	// Toggle focus from sidebar to chat (should fail)
+	cmd := m.toggleFocus()
+
+	// Verify focus stayed on sidebar
+	if m.focus != FocusSidebar {
+		t.Errorf("expected focus to stay on FocusSidebar, got %v", m.focus)
+	}
+
+	// Verify sidebar is still focused
+	if !m.sidebar.IsFocused() {
+		t.Error("expected sidebar to remain focused")
+	}
+
+	// Verify chat is not focused
+	if m.chat.IsFocused() {
+		t.Error("expected chat to remain unfocused")
+	}
+
+	// Verify no command is returned
+	if cmd != nil {
+		t.Errorf("expected nil command, got %v", cmd)
+	}
+}
+
+func TestToggleFocus_ChatToSidebar(t *testing.T) {
+	cfg := testConfigWithSessions()
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Select the first session to make it active
+	m.activeSession = &cfg.Sessions[0]
+	m.focus = FocusChat
+
+	// Set initial focus state
+	m.sidebar.SetFocused(false)
+	m.chat.SetFocused(true)
+
+	// Toggle focus from chat to sidebar
+	cmd := m.toggleFocus()
+
+	// Verify focus switched to sidebar
+	if m.focus != FocusSidebar {
+		t.Errorf("expected focus to be FocusSidebar, got %v", m.focus)
+	}
+
+	// Verify sidebar is focused
+	if !m.sidebar.IsFocused() {
+		t.Error("expected sidebar to be focused")
+	}
+
+	// Verify chat is unfocused
+	if m.chat.IsFocused() {
+		t.Error("expected chat to be unfocused")
+	}
+
+	// Verify no command is returned (regression test for issue #147)
+	if cmd != nil {
+		t.Errorf("expected nil command, got %v", cmd)
+	}
+}


### PR DESCRIPTION
## Summary
Removes dead code from `toggleFocus()` that was batching an empty command slice. The function now correctly returns `nil` in all cases.

## Changes
- Remove unused `cmds` slice variable from `toggleFocus()`
- Remove unreachable `tea.Batch(cmds...)` logic
- Add comprehensive unit tests for focus toggle behavior
  - Test sidebar → chat with active session
  - Test sidebar → chat without active session (should fail)
  - Test chat → sidebar

## Test plan
- Run `go test ./internal/app -run TestToggleFocus`
- Verify all three test cases pass
- Manually test Tab key to toggle focus between sidebar and chat
- Verify focus doesn't switch to chat when no session is active

Fixes #147