### PR TITLE
fix(ui): prevent stopwatch animation from stopping during tool use rollup

### DIFF
--- a/internal/ui/chat_animation.go
+++ b/internal/ui/chat_animation.go
@@ -351,8 +351,8 @@ func (c *Chat) IsWaiting() bool {
 
 // handleStopwatchTick handles the spinner animation tick
 func (c *Chat) handleStopwatchTick() tea.Cmd {
-	// Continue ticking while waiting for response OR actively streaming
-	if !c.waiting && c.streaming == "" {
+	// Continue ticking while waiting for response OR actively streaming OR active tool use rollup
+	if !c.waiting && c.streaming == "" && c.toolUseRollup == nil {
 		return nil
 	}
 

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -1816,6 +1816,46 @@ func TestChat_StopwatchContinuesDuringStreaming(t *testing.T) {
 	}
 }
 
+// TestChat_StopwatchContinuesDuringToolUseRollup verifies that the stopwatch tick
+// continues while tool use rollup is active, even without streaming text.
+func TestChat_StopwatchContinuesDuringToolUseRollup(t *testing.T) {
+	chat := NewChat()
+	chat.SetSession("test", nil)
+	chat.SetSize(80, 24)
+
+	// Start waiting
+	chat.SetWaiting(true)
+	cmd := chat.handleStopwatchTick()
+	if cmd == nil {
+		t.Error("Expected stopwatch to tick while waiting")
+	}
+
+	// Simulate tool-only streaming phase: waiting becomes false, no text streaming, but tool use rollup is active
+	chat.waiting = false
+	chat.streaming = ""
+	chat.AppendToolUse("Bash", "ls -la", "tool-1")
+
+	// The stopwatch should STILL tick while tool use rollup is active
+	cmd = chat.handleStopwatchTick()
+	if cmd == nil {
+		t.Error("Expected stopwatch to continue ticking while tool use rollup is active (Issue #144)")
+	}
+
+	// Add another tool use to the rollup
+	chat.AppendToolUse("Read", "/path/to/file", "tool-2")
+	cmd = chat.handleStopwatchTick()
+	if cmd == nil {
+		t.Error("Expected stopwatch to continue ticking with multiple tool uses in rollup")
+	}
+
+	// After tool use rollup is cleared, ticks should stop
+	chat.toolUseRollup = nil
+	cmd = chat.handleStopwatchTick()
+	if cmd != nil {
+		t.Error("Expected stopwatch to stop after tool use rollup is cleared")
+	}
+}
+
 func TestChat_FocusState(t *testing.T) {
 	chat := NewChat()
 


### PR DESCRIPTION
## Summary
Fixes the stopwatch animation stopping prematurely when Claude performs tool operations without accompanying text streaming. The animation now continues during the tool use rollup phase, providing better visual feedback that work is in progress.

## Changes
- Modified `handleStopwatchTick()` to check for active tool use rollup (`c.toolUseRollup != nil`) in addition to waiting and streaming states
- Added comprehensive test case `TestChat_StopwatchContinuesDuringToolUseRollup` that verifies the stopwatch continues during tool-only phases

## Test plan
- Run `go test ./internal/ui -v -run TestChat_StopwatchContinuesDuringToolUseRollup` to verify the new test passes
- Manually test by triggering a Claude session that performs multiple tool operations (e.g., reading files, running commands) - the stopwatch should continue animating throughout
- Verify the stopwatch stops correctly after tool use rollup is cleared and no other activity is ongoing

Fixes #144