### PR TITLE
fix(shortcuts): remove duplicate ctrl-d quit shortcut

### DIFF
--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -251,13 +251,6 @@ var ShortcutRegistry = []Shortcut{
 		RequiresSidebar: true,
 		Handler:         shortcutQuit,
 	},
-	{
-		Key:         keys.CtrlD,
-		DisplayKey:  "ctrl-d",
-		Description: "Quit application",
-		Category:    CategoryGeneral,
-		Handler:     shortcutQuit,
-	},
 }
 
 // helpShortcut is defined separately to avoid initialization cycle.
@@ -275,6 +268,7 @@ var DisplayOnlyShortcuts = []Shortcut{
 	// Navigation (display-only)
 	{DisplayKey: "↑/↓ or j/k", Description: "Navigate session list", Category: CategoryNavigation},
 	{DisplayKey: "PgUp/PgDn", Description: "Scroll chat or session list", Category: CategoryNavigation},
+	{DisplayKey: "ctrl-u/ctrl-d", Description: "Scroll half page up/down", Category: CategoryNavigation},
 	{DisplayKey: "Enter", Description: "Select session / Send message", Category: CategoryNavigation},
 	{DisplayKey: "Esc", Description: "Cancel search / Stop streaming", Category: CategoryNavigation},
 


### PR DESCRIPTION
## Summary
Removes the duplicate `ctrl-d` shortcut for quitting the application from the executable shortcuts registry. The `ctrl-d` keybinding is now only used for scrolling half page down (matching standard vim/terminal behavior).

## Changes
- Removed duplicate `ctrl-d` shortcut entry from `ShortcutRegistry` that was mapped to quit
- Kept `ctrl-d` in `DisplayOnlyShortcuts` as part of `ctrl-u/ctrl-d` for half-page scrolling
- `ctrl-q` remains as the primary quit shortcut

## Test plan
- Build and run the application
- Verify `ctrl-q` still quits the application
- Verify `ctrl-d` scrolls half page down in chat/session list (does not quit)
- Open help modal (`?`) and confirm shortcut list shows correct bindings:
  - `ctrl-q` for "Quit application"
  - `ctrl-u/ctrl-d` for "Scroll half page up/down" under Navigation

Fixes #155