### PR TITLE
Remove description truncation in MCP permission server

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -629,7 +629,7 @@ func buildToolDescription(tool string, input map[string]interface{}) string {
 		}
 	case "Bash":
 		if cmd, ok := input["command"].(string); ok {
-			return "Run: " + truncateString(cmd, 100)
+			return "Run: " + cmd
 		}
 	case "Glob":
 		if pattern, ok := input["pattern"].(string); ok {
@@ -652,7 +652,7 @@ func buildToolDescription(tool string, input map[string]interface{}) string {
 			return "Delegate task: " + desc
 		}
 		if prompt, ok := input["prompt"].(string); ok {
-			return "Delegate task: " + truncateString(prompt, 60)
+			return "Delegate task: " + prompt
 		}
 	case "WebFetch":
 		if url, ok := input["url"].(string); ok {
@@ -672,7 +672,7 @@ func buildToolDescription(tool string, input map[string]interface{}) string {
 			return tool + ": " + filePath
 		}
 		if cmd, ok := input["command"].(string); ok {
-			return tool + ": " + truncateString(cmd, 80)
+			return tool + ": " + cmd
 		}
 		if url, ok := input["url"].(string); ok {
 			return tool + ": " + url
@@ -730,7 +730,7 @@ func formatValue(key string, value interface{}) string {
 		if v == "" {
 			return ""
 		}
-		return displayKey + ": " + truncateString(v, 100)
+		return displayKey + ": " + v
 	case bool:
 		if v {
 			return displayKey + ": yes"
@@ -810,7 +810,7 @@ func formatNestedObject(obj map[string]interface{}) string {
 			v := obj[k]
 			switch val := v.(type) {
 			case string:
-				parts = append(parts, humanizeKey(k)+": "+truncateString(val, 40))
+				parts = append(parts, humanizeKey(k)+": "+val)
 			case bool:
 				if val {
 					parts = append(parts, humanizeKey(k)+": yes")
@@ -834,7 +834,7 @@ func formatArray(arr []interface{}) string {
 	}
 	if len(arr) == 1 {
 		if s, ok := arr[0].(string); ok {
-			return truncateString(s, 60)
+			return s
 		}
 		return fmt.Sprintf("%v", arr[0])
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -49,12 +49,12 @@ func TestBuildToolDescription(t *testing.T) {
 			expected: "Run: ls -la",
 		},
 		{
-			name: "Bash with long command truncated",
+			name: "Bash with long command not truncated",
 			tool: "Bash",
 			input: map[string]interface{}{
 				"command": strings.Repeat("a", 150),
 			},
-			expected: "Run: " + strings.Repeat("a", 97) + "...",
+			expected: "Run: " + strings.Repeat("a", 150),
 		},
 		{
 			name: "Glob with pattern only",
@@ -415,12 +415,12 @@ func TestBuildToolDescription_EdgeCases(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "Task with long prompt truncated",
+			name: "Task with long prompt not truncated",
 			tool: "Task",
 			input: map[string]interface{}{
 				"prompt": strings.Repeat("x", 100),
 			},
-			expected: "Delegate task: " + strings.Repeat("x", 57) + "...",
+			expected: "Delegate task: " + strings.Repeat("x", 100),
 		},
 	}
 


### PR DESCRIPTION
This PR completes the fix for issue #154 by removing truncation from the MCP server layer.

## The Problem
While the UI rendering fix (merged in #XXX) properly wraps long text, the MCP permission server was still truncating command descriptions before sending them to the UI:
- Bash commands: truncated to 100 chars with `...`
- Task prompts: truncated to 60 chars
- Generic commands: truncated to 80 chars
- Nested objects/arrays: truncated to 40-60 chars

This meant users saw incomplete commands like:
```
Run: git commit -m "$(cat <<'EOF'\nUpdate authentication flow to support OAuth 2.0\n\nThis is a ver...
```

## The Fix
Remove all `truncateString()` calls from:
- `buildToolDescription()` - Bash, Task, and default command cases
- `formatValue()` - String value formatting
- `formatNestedObject()` - Nested data formatting  
- `formatArray()` - Array formatting

Now the MCP server sends full, untruncated descriptions to the UI, which properly wraps them within the 80-char box.

## Result
Users can now see complete permission requests, even for very long git commands with heredocs and multi-line commit messages.

## Testing
- ✅ All tests updated and passing
- ✅ Tests verify no truncation occurs
- ✅ Works with the UI wrapping fix already merged

Fixes #154