### PR TITLE
fix(ui): disable line numbers in broadcast modal textareas

### DIFF
--- a/internal/ui/modals/broadcast.go
+++ b/internal/ui/modals/broadcast.go
@@ -371,6 +371,7 @@ func NewBroadcastState(repoPaths []string, containersSupported bool, containerAu
 	promptInput := textarea.New()
 	promptInput.Placeholder = "Enter prompt to send to all selected repos..."
 	promptInput.CharLimit = 10000
+	promptInput.ShowLineNumbers = false
 	promptInput.SetWidth(ModalWidth - 6) // Account for padding/borders
 	promptInput.SetHeight(4)
 	promptInput.Prompt = "" // Remove default prompt to avoid double bar with focus border
@@ -717,6 +718,7 @@ func NewBroadcastGroupState(groupID string, sessions []SessionItem) *BroadcastGr
 	promptInput := textarea.New()
 	promptInput.Placeholder = "Enter prompt to send to selected sessions..."
 	promptInput.CharLimit = 10000
+	promptInput.ShowLineNumbers = false
 	promptInput.SetWidth(ModalWidth - 6)
 	promptInput.SetHeight(4)
 	promptInput.Prompt = ""

--- a/internal/ui/modals/broadcast_test.go
+++ b/internal/ui/modals/broadcast_test.go
@@ -41,6 +41,11 @@ func TestNewBroadcastState(t *testing.T) {
 	if state.SelectedIndex != 0 {
 		t.Errorf("expected initial SelectedIndex 0, got %d", state.SelectedIndex)
 	}
+
+	// Check textarea has line numbers disabled
+	if state.PromptInput.ShowLineNumbers {
+		t.Error("expected ShowLineNumbers to be false")
+	}
 }
 
 func TestBroadcastState_Title(t *testing.T) {
@@ -448,6 +453,11 @@ func TestNewBroadcastGroupState(t *testing.T) {
 	// Check group ID is set
 	if state.GroupID != "group123" {
 		t.Errorf("expected group ID 'group123', got %s", state.GroupID)
+	}
+
+	// Check textarea has line numbers disabled
+	if state.PromptInput.ShowLineNumbers {
+		t.Error("expected ShowLineNumbers to be false")
 	}
 }
 

--- a/internal/ui/modals/styles.go
+++ b/internal/ui/modals/styles.go
@@ -136,6 +136,9 @@ func ApplyTextareaStyles(ta *textarea.Model) {
 	styles.Focused.Text = textStyle
 	styles.Focused.Placeholder = placeholderStyle
 	styles.Focused.CursorLine = textStyle // Remove background from cursor line
+	styles.Focused.CursorLineNumber = textStyle
+	styles.Focused.LineNumber = textStyle
+	styles.Focused.EndOfBuffer = baseStyle
 	styles.Focused.Prompt = textStyle
 
 	// Configure blurred state (same colors, just not focused)
@@ -143,6 +146,9 @@ func ApplyTextareaStyles(ta *textarea.Model) {
 	styles.Blurred.Text = textStyle
 	styles.Blurred.Placeholder = placeholderStyle
 	styles.Blurred.CursorLine = textStyle
+	styles.Blurred.CursorLineNumber = textStyle
+	styles.Blurred.LineNumber = textStyle
+	styles.Blurred.EndOfBuffer = baseStyle
 	styles.Blurred.Prompt = textStyle
 
 	ta.SetStyles(styles)


### PR DESCRIPTION
## Summary
Removes line numbers from the broadcast modal textareas, which are meant for prompt input rather than code editing.

## Changes
- Set `ShowLineNumbers = false` on prompt textareas in both `NewBroadcastState` and `NewBroadcastGroupState`
- Style the line number and end-of-buffer elements in `ApplyTextareaStyles` for both focused and blurred states
- Add tests verifying line numbers are disabled in both broadcast modals

## Test plan
- `go test ./internal/ui/modals/...` — new assertions confirm `ShowLineNumbers` is false
- Open the broadcast modal (`Ctrl+B`) and broadcast group modal (`Ctrl+Shift+B`) in the TUI and verify no line numbers appear in the prompt textarea

Fixes #191