### PR TITLE
Fix bulk action modal textarea styling

### DIFF
--- a/internal/ui/modals/bulk_action.go
+++ b/internal/ui/modals/bulk_action.go
@@ -250,10 +250,15 @@ func (s *BulkActionState) GetPrompt() string {
 func NewBulkActionState(sessionIDs []string, workspaces []config.Workspace) *BulkActionState {
 	promptInput := textarea.New()
 	promptInput.Placeholder = "Enter your prompt here..."
+	promptInput.CharLimit = 10000
 	promptInput.ShowLineNumbers = false
-	promptInput.SetWidth(60)
+	promptInput.SetWidth(ModalWidth - 6) // Account for padding/borders
 	promptInput.SetHeight(4)
+	promptInput.Prompt = "" // Remove default prompt to avoid double bar with focus border
 	// Don't focus immediately - focus when user navigates to Send Prompt action
+
+	// Apply transparent background styles
+	ApplyTextareaStyles(&promptInput)
 
 	return &BulkActionState{
 		SessionIDs:   sessionIDs,

--- a/internal/ui/modals/bulk_action_test.go
+++ b/internal/ui/modals/bulk_action_test.go
@@ -28,6 +28,11 @@ func TestNewBulkActionState(t *testing.T) {
 	if len(state.Workspaces) != 1 {
 		t.Errorf("expected 1 workspace, got %d", len(state.Workspaces))
 	}
+
+	// Check textarea has line numbers disabled
+	if state.PromptInput.ShowLineNumbers {
+		t.Error("expected ShowLineNumbers to be false")
+	}
 }
 
 func TestBulkActionState_SwitchAction(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes double left bars in bulk action modal's "Send Prompt" textarea by removing the default textarea prompt character
- Fixes solid black background behind textarea input by applying transparent background styles (`ApplyTextareaStyles`)
- Aligns textarea config with broadcast modal (char limit, dynamic width)

Closes #191

## Test plan
- [x] All existing bulk action modal tests pass
- [x] New test added for `ShowLineNumbers = false`
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)