### PR TITLE
feat(chat): add Shift+Enter to insert newlines in chat input

### DIFF
--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -273,6 +273,7 @@ var DisplayOnlyShortcuts = []Shortcut{
 	{DisplayKey: "Esc", Description: "Cancel search / Stop streaming", Category: CategoryNavigation},
 
 	// Chat (display-only, context-sensitive)
+	{DisplayKey: "Shift+Enter", Description: "Insert newline", Category: CategoryChat},
 	{DisplayKey: "ctrl-v", Description: "Paste image", Category: CategoryChat},
 	{DisplayKey: "ctrl-o", Description: "Fork detected options", Category: CategoryChat},
 	{DisplayKey: "Mouse drag", Description: "Select text (auto-copies)", Category: CategoryChat},

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -24,13 +24,14 @@ var (
 
 // Action keys
 var (
-	Enter     = tea.KeyPressMsg{Code: tea.KeyEnter}.String()                     // "enter"
-	Tab       = tea.KeyPressMsg{Code: tea.KeyTab}.String()                       // "tab"
-	ShiftTab  = (tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}).String()  // "shift+tab"
-	Space     = tea.KeyPressMsg{Code: tea.KeySpace}.String()                     // "space"
-	Backspace = tea.KeyPressMsg{Code: tea.KeyBackspace}.String()                 // "backspace"
-	Delete    = tea.KeyPressMsg{Code: tea.KeyDelete}.String()                    // "delete"
-	Escape    = tea.KeyPressMsg{Code: tea.KeyEscape}.String()                    // "esc"
+	Enter      = tea.KeyPressMsg{Code: tea.KeyEnter}.String()                      // "enter"
+	ShiftEnter = (tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}).String() // "shift+enter"
+	Tab        = tea.KeyPressMsg{Code: tea.KeyTab}.String()                        // "tab"
+	ShiftTab   = (tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}).String()   // "shift+tab"
+	Space      = tea.KeyPressMsg{Code: tea.KeySpace}.String()                      // "space"
+	Backspace  = tea.KeyPressMsg{Code: tea.KeyBackspace}.String()                  // "backspace"
+	Delete     = tea.KeyPressMsg{Code: tea.KeyDelete}.String()                     // "delete"
+	Escape     = tea.KeyPressMsg{Code: tea.KeyEscape}.String()                     // "esc"
 )
 
 // Ctrl combinations

--- a/internal/keys/keys_test.go
+++ b/internal/keys/keys_test.go
@@ -23,6 +23,7 @@ func TestKeyStringValues(t *testing.T) {
 
 		// Actions
 		{"Enter", Enter, "enter"},
+		{"ShiftEnter", ShiftEnter, "shift+enter"},
 		{"Tab", Tab, "tab"},
 		{"ShiftTab", ShiftTab, "shift+tab"},
 		{"Space", Space, "space"},

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1546,6 +1546,11 @@ func (c *Chat) Update(msg tea.Msg) (*Chat, tea.Cmd) {
 			case keys.Tab:
 				// Don't let textarea consume Tab - let it bubble up for focus switching
 				return c, tea.Batch(cmds...)
+			case keys.ShiftEnter:
+				// Convert Shift+Enter to plain Enter so textarea inserts a newline.
+				// Plain Enter is intercepted by the app to send messages, so
+				// Shift+Enter is the way users can add newlines to their input.
+				msg = tea.KeyPressMsg{Code: tea.KeyEnter}
 			case keys.Escape:
 				// Clear text selection if there is one
 				if c.HasTextSelection() {

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -1752,6 +1752,46 @@ func TestChat_Input(t *testing.T) {
 	}
 }
 
+func TestChat_ShiftEnterInsertsNewline(t *testing.T) {
+	chat := NewChat()
+	chat.SetSession("test", nil)
+	chat.SetSize(80, 24)
+	chat.SetFocused(true)
+
+	// Type some text first
+	chat.SetInput("line one")
+
+	// Send Shift+Enter — should insert a newline
+	shiftEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}
+	chat, _ = chat.Update(shiftEnter)
+
+	// Type more text after the newline
+	for _, ch := range "line two" {
+		chat, _ = chat.Update(tea.KeyPressMsg{Code: -1, Text: string(ch)})
+	}
+
+	// The input should contain both lines separated by a newline.
+	// GetInput() trims whitespace, so we check the raw textarea value.
+	raw := chat.input.Value()
+	if !strings.Contains(raw, "\n") {
+		t.Errorf("Expected newline in textarea after Shift+Enter, got %q", raw)
+	}
+	if !strings.Contains(raw, "line one") || !strings.Contains(raw, "line two") {
+		t.Errorf("Expected both lines in textarea, got %q", raw)
+	}
+}
+
+func TestChat_ShiftEnterKeyStringDiffersFromEnter(t *testing.T) {
+	// Verify that Shift+Enter produces a different key string than Enter,
+	// ensuring the app-level Enter handler won't intercept it.
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	shiftEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}
+
+	if enter.String() == shiftEnter.String() {
+		t.Errorf("Enter and Shift+Enter should have different key strings, both are %q", enter.String())
+	}
+}
+
 func TestChat_Waiting(t *testing.T) {
 	chat := NewChat()
 

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -303,6 +303,7 @@ func (f *Footer) View() string {
 		// Chat focused, not streaming - show enter and ctrl+v
 		chatBindings := []KeyBinding{
 			{Key: "enter", Desc: "send"},
+			{Key: "shift+enter", Desc: "newline"},
 		}
 		// Show ctrl+o when options are detected
 		if f.hasDetectedOptions {


### PR DESCRIPTION
## Summary
Adds Shift+Enter as a keyboard shortcut to insert newlines in the chat input textarea, since plain Enter is used to send messages.

## Changes
- Add `ShiftEnter` key constant to `internal/keys/keys.go`
- Intercept Shift+Enter in chat's `Update()` and convert it to a plain Enter so the textarea inserts a newline
- Display "shift+enter → newline" in the footer keybindings when chat is focused
- Add Shift+Enter to the help modal's display-only shortcuts
- Add tests for the new key constant and newline insertion behavior

## Test plan
- `go test ./internal/keys/...` — verifies `ShiftEnter` key string is correct
- `go test ./internal/ui/...` — verifies Shift+Enter inserts a newline in the textarea and that the key string differs from plain Enter
- Manual: focus the chat input, press Shift+Enter, confirm a newline is inserted instead of sending the message

Fixes #188