### PR TITLE
fix: propagate save errors from session message persistence

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -422,15 +422,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.sidebar.SetStreaming(m.activeSession.ID, false)
 						m.chat.SetWaiting(false)
 						// Save partial response to runner before finishing
+						var saveErr error
 						if content := m.chat.GetStreaming(); content != "" {
 							m.claudeRunner.AddAssistantMessage(content + "\n[Interrupted]")
-							m.sessionMgr.SaveRunnerMessages(m.activeSession.ID, m.claudeRunner)
+							saveErr = m.sessionMgr.SaveRunnerMessages(m.activeSession.ID, m.claudeRunner)
 						}
 						m.chat.AppendStreaming("\n[Interrupted]\n")
 						m.chat.FinishStreaming()
 						// Check if any sessions are still streaming
 						if !m.hasAnyStreamingSessions() {
 							m.setState(StateIdle)
+						}
+						if saveErr != nil {
+							return m, m.ShowFlashError("Failed to save session messages")
 						}
 						return m, nil
 					}

--- a/internal/app/session_manager.go
+++ b/internal/app/session_manager.go
@@ -384,12 +384,12 @@ func (sm *SessionManager) GetOrCreateRunner(sess *config.Session) claude.RunnerI
 }
 
 // SaveMessages saves the current messages from a runner to disk.
-func (sm *SessionManager) SaveMessages(sessionID string) {
+func (sm *SessionManager) SaveMessages(sessionID string) error {
 	sm.mu.RLock()
 	runner, exists := sm.runners[sessionID]
 	sm.mu.RUnlock()
 	if !exists || runner == nil {
-		return
+		return nil
 	}
 
 	msgs := runner.GetMessages()
@@ -401,13 +401,17 @@ func (sm *SessionManager) SaveMessages(sessionID string) {
 		})
 	}
 
-	config.SaveSessionMessages(sessionID, configMsgs, config.MaxSessionMessageLines)
+	if err := config.SaveSessionMessages(sessionID, configMsgs, config.MaxSessionMessageLines); err != nil {
+		logger.WithSession(sessionID).Error("failed to save session messages", "error", err)
+		return err
+	}
+	return nil
 }
 
 // SaveRunnerMessages saves messages for a specific runner (used when runner reference is already available).
-func (sm *SessionManager) SaveRunnerMessages(sessionID string, runner claude.RunnerInterface) {
+func (sm *SessionManager) SaveRunnerMessages(sessionID string, runner claude.RunnerInterface) error {
 	if runner == nil {
-		return
+		return nil
 	}
 
 	msgs := runner.GetMessages()
@@ -419,7 +423,11 @@ func (sm *SessionManager) SaveRunnerMessages(sessionID string, runner claude.Run
 		})
 	}
 
-	config.SaveSessionMessages(sessionID, configMsgs, config.MaxSessionMessageLines)
+	if err := config.SaveSessionMessages(sessionID, configMsgs, config.MaxSessionMessageLines); err != nil {
+		logger.WithSession(sessionID).Error("failed to save session messages", "error", err)
+		return err
+	}
+	return nil
 }
 
 // DeleteSession cleans up all resources for a deleted session.

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -897,3 +897,117 @@ func TestCopyClaudeSessionForFork_SuccessPath(t *testing.T) {
 	}
 }
 
+func TestSessionManager_SaveMessages_NoRunner(t *testing.T) {
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	// No runner exists - should return nil (no error)
+	err := sm.SaveMessages("nonexistent")
+	if err != nil {
+		t.Errorf("SaveMessages with no runner should return nil, got %v", err)
+	}
+}
+
+func TestSessionManager_SaveMessages_Success(t *testing.T) {
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	// Create a mock runner with messages
+	runner := claude.NewMockRunner("session-1", true, []claude.Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi there"},
+	})
+	sm.SetRunner("session-1", runner)
+
+	err := sm.SaveMessages("session-1")
+	if err != nil {
+		t.Errorf("SaveMessages should succeed, got %v", err)
+	}
+
+	// Verify messages were saved
+	msgs, loadErr := config.LoadSessionMessages("session-1")
+	if loadErr != nil {
+		t.Fatalf("Failed to load saved messages: %v", loadErr)
+	}
+	if len(msgs) != 2 {
+		t.Errorf("Expected 2 messages, got %d", len(msgs))
+	}
+}
+
+func TestSessionManager_SaveMessages_Error(t *testing.T) {
+	// Set HOME to a read-only path to trigger a write error
+	tempDir := t.TempDir()
+	readOnlyDir := filepath.Join(tempDir, "readonly")
+	os.MkdirAll(readOnlyDir, 0500)
+	defer os.Chmod(readOnlyDir, 0700)
+	t.Setenv("HOME", readOnlyDir)
+
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("session-1", true, []claude.Message{
+		{Role: "user", Content: "Hello"},
+	})
+	sm.SetRunner("session-1", runner)
+
+	err := sm.SaveMessages("session-1")
+	if err == nil {
+		t.Error("SaveMessages should return error when write fails")
+	}
+}
+
+func TestSessionManager_SaveRunnerMessages_NilRunner(t *testing.T) {
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	err := sm.SaveRunnerMessages("session-1", nil)
+	if err != nil {
+		t.Errorf("SaveRunnerMessages with nil runner should return nil, got %v", err)
+	}
+}
+
+func TestSessionManager_SaveRunnerMessages_Success(t *testing.T) {
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("session-1", true, []claude.Message{
+		{Role: "user", Content: "Test message"},
+		{Role: "assistant", Content: "Test response"},
+	})
+
+	err := sm.SaveRunnerMessages("session-1", runner)
+	if err != nil {
+		t.Errorf("SaveRunnerMessages should succeed, got %v", err)
+	}
+
+	// Verify messages were saved
+	msgs, loadErr := config.LoadSessionMessages("session-1")
+	if loadErr != nil {
+		t.Fatalf("Failed to load saved messages: %v", loadErr)
+	}
+	if len(msgs) != 2 {
+		t.Errorf("Expected 2 messages, got %d", len(msgs))
+	}
+}
+
+func TestSessionManager_SaveRunnerMessages_Error(t *testing.T) {
+	// Set HOME to a read-only path to trigger a write error
+	tempDir := t.TempDir()
+	readOnlyDir := filepath.Join(tempDir, "readonly")
+	os.MkdirAll(readOnlyDir, 0500)
+	defer os.Chmod(readOnlyDir, 0700)
+	t.Setenv("HOME", readOnlyDir)
+
+	cfg := createTestConfig()
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("session-1", true, []claude.Message{
+		{Role: "user", Content: "Hello"},
+	})
+
+	err := sm.SaveRunnerMessages("session-1", runner)
+	if err == nil {
+		t.Error("SaveRunnerMessages should return error when write fails")
+	}
+}
+


### PR DESCRIPTION
## Summary
Propagate errors from session message persistence instead of silently swallowing them, and remove the deadcode CI workflow that produced false positives.

## Changes
- Change `SaveMessages()` and `SaveRunnerMessages()` to return `error` instead of silently discarding write failures
- Surface save errors to users via flash error messages in the TUI
- Log save errors with session context for debugging
- Add tests for save/error paths in `SaveMessages` and `SaveRunnerMessages`
- Remove the `deadcode.yml` CI workflow and its false-positive disclaimer comment on `MockRunner`

## Test plan
- Run `go test ./internal/app/...` to verify new session manager save error tests pass
- Run `go test ./...` to verify no regressions across the codebase
- Verify that callers of `SaveMessages`/`SaveRunnerMessages` in `app.go` and `msg_handlers.go` now handle the returned error

Fixes #137