### PR TITLE
feat(chat): add Option+Enter as alternative newline shortcut

### DIFF
--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -273,7 +273,7 @@ var DisplayOnlyShortcuts = []Shortcut{
 	{DisplayKey: "Esc", Description: "Cancel search / Stop streaming", Category: CategoryNavigation},
 
 	// Chat (display-only, context-sensitive)
-	{DisplayKey: "Shift+Enter", Description: "Insert newline", Category: CategoryChat},
+	{DisplayKey: "Opt+Enter", Description: "Insert newline", Category: CategoryChat},
 	{DisplayKey: "ctrl-v", Description: "Paste image", Category: CategoryChat},
 	{DisplayKey: "ctrl-o", Description: "Fork detected options", Category: CategoryChat},
 	{DisplayKey: "Mouse drag", Description: "Select text (auto-copies)", Category: CategoryChat},

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -26,6 +26,7 @@ var (
 var (
 	Enter      = tea.KeyPressMsg{Code: tea.KeyEnter}.String()                      // "enter"
 	ShiftEnter = (tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}).String() // "shift+enter"
+	AltEnter   = (tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}).String()   // "alt+enter"
 	Tab        = tea.KeyPressMsg{Code: tea.KeyTab}.String()                        // "tab"
 	ShiftTab   = (tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}).String()   // "shift+tab"
 	Space      = tea.KeyPressMsg{Code: tea.KeySpace}.String()                      // "space"

--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1546,10 +1546,11 @@ func (c *Chat) Update(msg tea.Msg) (*Chat, tea.Cmd) {
 			case keys.Tab:
 				// Don't let textarea consume Tab - let it bubble up for focus switching
 				return c, tea.Batch(cmds...)
-			case keys.ShiftEnter:
-				// Convert Shift+Enter to plain Enter so textarea inserts a newline.
-				// Plain Enter is intercepted by the app to send messages, so
-				// Shift+Enter is the way users can add newlines to their input.
+			case keys.ShiftEnter, keys.AltEnter:
+				// Convert Shift+Enter or Option+Enter to plain Enter so textarea inserts a newline.
+				// Plain Enter is intercepted by the app to send messages, so these
+				// modified-Enter combos are the way users can add newlines to their input.
+				// Option+Enter works in all terminals; Shift+Enter requires Kitty keyboard protocol.
 				msg = tea.KeyPressMsg{Code: tea.KeyEnter}
 			case keys.Escape:
 				// Clear text selection if there is one

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -1781,14 +1781,46 @@ func TestChat_ShiftEnterInsertsNewline(t *testing.T) {
 	}
 }
 
-func TestChat_ShiftEnterKeyStringDiffersFromEnter(t *testing.T) {
-	// Verify that Shift+Enter produces a different key string than Enter,
-	// ensuring the app-level Enter handler won't intercept it.
+func TestChat_AltEnterInsertsNewline(t *testing.T) {
+	chat := NewChat()
+	chat.SetSession("test", nil)
+	chat.SetSize(80, 24)
+	chat.SetFocused(true)
+
+	// Type some text first
+	chat.SetInput("line one")
+
+	// Send Alt+Enter — should insert a newline (works in all terminals)
+	altEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}
+	chat, _ = chat.Update(altEnter)
+
+	// Type more text after the newline
+	for _, ch := range "line two" {
+		chat, _ = chat.Update(tea.KeyPressMsg{Code: -1, Text: string(ch)})
+	}
+
+	// The input should contain both lines separated by a newline.
+	raw := chat.input.Value()
+	if !strings.Contains(raw, "\n") {
+		t.Errorf("Expected newline in textarea after Alt+Enter, got %q", raw)
+	}
+	if !strings.Contains(raw, "line one") || !strings.Contains(raw, "line two") {
+		t.Errorf("Expected both lines in textarea, got %q", raw)
+	}
+}
+
+func TestChat_NewlineKeyStringsDifferFromEnter(t *testing.T) {
+	// Verify that Shift+Enter and Alt+Enter produce different key strings than Enter,
+	// ensuring the app-level Enter handler won't intercept them.
 	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
 	shiftEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}
+	altEnter := tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}
 
 	if enter.String() == shiftEnter.String() {
 		t.Errorf("Enter and Shift+Enter should have different key strings, both are %q", enter.String())
+	}
+	if enter.String() == altEnter.String() {
+		t.Errorf("Enter and Alt+Enter should have different key strings, both are %q", enter.String())
 	}
 }
 

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -303,7 +303,7 @@ func (f *Footer) View() string {
 		// Chat focused, not streaming - show enter and ctrl+v
 		chatBindings := []KeyBinding{
 			{Key: "enter", Desc: "send"},
-			{Key: "shift+enter", Desc: "newline"},
+			{Key: "opt+enter", Desc: "newline"},
 		}
 		// Show ctrl+o when options are detected
 		if f.hasDetectedOptions {


### PR DESCRIPTION
## Summary
Add Option+Enter (Alt+Enter) as an alternative way to insert newlines in the chat input, since it works reliably in all terminals unlike Shift+Enter which requires Kitty keyboard protocol support.

## Changes
- Add `AltEnter` key constant (`alt+enter`) to the keys package
- Handle `keys.AltEnter` alongside `keys.ShiftEnter` in chat input to insert newlines
- Update display-only shortcuts and footer keybindings to show `Opt+Enter` instead of `Shift+Enter`
- Add tests for Alt+Enter newline insertion and key string differentiation

## Test plan
- Run `go test ./internal/ui/...` to verify new and updated tests pass
- Launch the TUI and confirm Option+Enter inserts a newline in the chat input
- Confirm Shift+Enter still works as before
- Check that the help modal and footer show `Opt+Enter` for the newline shortcut