### PR TITLE
Show shift+enter for newline when terminal supports Kitty protocol

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,6 +91,9 @@ type Model struct {
 
 	// Pending container action to execute after async prerequisite checks pass (nil when inactive)
 	pendingContainerAction func() (tea.Model, tea.Cmd)
+
+	// Terminal capability flags
+	kittyKeyboard bool // Terminal supports Kitty keyboard protocol (Shift+Enter distinguishable)
 }
 
 // StartupModalMsg is sent on app start to trigger welcome/changelog modals
@@ -353,6 +356,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.BlurMsg:
 		m.windowFocused = false
 		logger.Get().Debug("window blurred")
+
+	case tea.KeyboardEnhancementsMsg:
+		m.kittyKeyboard = msg.SupportsKeyDisambiguation()
+		logger.Get().Debug("keyboard enhancements detected", "kitty", m.kittyKeyboard, "flags", msg.Flags)
 
 	case tea.PasteStartMsg:
 		// Handle paste events - check for images in clipboard when paste starts

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -575,7 +575,21 @@ func shortcutPlugins(m *Model) (tea.Model, tea.Cmd) {
 func shortcutHelp(m *Model) (tea.Model, tea.Cmd) {
 	// Include help shortcut in the registry for display purposes
 	allShortcuts := append(ShortcutRegistry, helpShortcut)
-	sections := m.getApplicableHelpSections(allShortcuts, DisplayOnlyShortcuts)
+
+	// Override newline shortcut display based on terminal capabilities
+	displayOnly := DisplayOnlyShortcuts
+	if m.kittyKeyboard {
+		displayOnly = make([]Shortcut, len(DisplayOnlyShortcuts))
+		copy(displayOnly, DisplayOnlyShortcuts)
+		for i := range displayOnly {
+			if displayOnly[i].DisplayKey == "Opt+Enter" && displayOnly[i].Description == "Insert newline" {
+				displayOnly[i].DisplayKey = "Shift+Enter"
+				break
+			}
+		}
+	}
+
+	sections := m.getApplicableHelpSections(allShortcuts, displayOnly)
 	m.modal.Show(ui.NewHelpStateFromSections(sections))
 	return m, nil
 }

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -44,7 +44,7 @@ func (m *Model) View() tea.View {
 	viewChangesMode := m.chat.IsInViewChangesMode()
 	searchMode := m.sidebar.IsSearchMode()
 	multiSelectMode := m.sidebar.IsMultiSelectMode()
-	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions)
+	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions, m.kittyKeyboard)
 
 	header := m.header.View()
 	footer := m.footer.View()
@@ -104,7 +104,7 @@ func (m *Model) RenderToString() string {
 	viewChangesMode := m.chat.IsInViewChangesMode()
 	searchMode := m.sidebar.IsSearchMode()
 	multiSelectMode := m.sidebar.IsMultiSelectMode()
-	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions)
+	m.footer.SetContext(hasSession, sidebarFocused, hasPendingPermission, hasPendingQuestion, isStreaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions, m.kittyKeyboard)
 
 	header := m.header.View()
 	footer := m.footer.View()

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -63,6 +63,7 @@ type Footer struct {
 	searchMode         bool // Whether sidebar is in search mode
 	multiSelectMode    bool // Whether sidebar is in multi-select mode
 	hasDetectedOptions bool // Whether chat has detected options for parallel exploration
+	kittyKeyboard      bool // Terminal supports Kitty keyboard protocol
 	flashMessage       *FlashMessage // Current flash message, if any
 }
 
@@ -84,7 +85,7 @@ func NewFooter() *Footer {
 }
 
 // SetContext updates the footer's context for conditional bindings
-func (f *Footer) SetContext(hasSession, sidebarFocused, pendingPermission, pendingQuestion, streaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions bool) {
+func (f *Footer) SetContext(hasSession, sidebarFocused, pendingPermission, pendingQuestion, streaming, viewChangesMode, searchMode, multiSelectMode, hasDetectedOptions, kittyKeyboard bool) {
 	f.hasSession = hasSession
 	f.sidebarFocused = sidebarFocused
 	f.pendingPermission = pendingPermission
@@ -94,6 +95,7 @@ func (f *Footer) SetContext(hasSession, sidebarFocused, pendingPermission, pendi
 	f.searchMode = searchMode
 	f.multiSelectMode = multiSelectMode
 	f.hasDetectedOptions = hasDetectedOptions
+	f.kittyKeyboard = kittyKeyboard
 }
 
 // SetWidth sets the footer width
@@ -300,10 +302,14 @@ func (f *Footer) View() string {
 			parts = append(parts, key+desc)
 		}
 	} else if !f.sidebarFocused && f.hasSession {
-		// Chat focused, not streaming - show enter and ctrl+v
+		// Chat focused, not streaming - show enter and newline shortcut
+		newlineKey := "opt+enter"
+		if f.kittyKeyboard {
+			newlineKey = "shift+enter"
+		}
 		chatBindings := []KeyBinding{
 			{Key: "enter", Desc: "send"},
-			{Key: "opt+enter", Desc: "newline"},
+			{Key: newlineKey, Desc: "newline"},
 		}
 		// Show ctrl+o when options are detected
 		if f.hasDetectedOptions {

--- a/internal/ui/footer_test.go
+++ b/internal/ui/footer_test.go
@@ -217,7 +217,7 @@ func TestFooter_MultiSelectMode(t *testing.T) {
 	footer.SetWidth(120)
 
 	// Default view should not show multi-select bindings
-	footer.SetContext(true, true, false, false, false, false, false, false, false)
+	footer.SetContext(true, true, false, false, false, false, false, false, false, false)
 	defaultView := footer.View()
 	if strings.Contains(defaultView, "toggle") {
 		t.Error("Default view should not contain multi-select 'toggle' binding")
@@ -227,7 +227,7 @@ func TestFooter_MultiSelectMode(t *testing.T) {
 	}
 
 	// Multi-select mode should show multi-select-specific bindings
-	footer.SetContext(true, true, false, false, false, false, false, true, false)
+	footer.SetContext(true, true, false, false, false, false, false, true, false, false)
 	multiSelectView := footer.View()
 
 	expectedBindings := []string{"toggle", "select all", "deselect all", "bulk action", "navigate", "exit", "help"}
@@ -251,7 +251,7 @@ func TestFooter_MultiSelectMode_FlashTakesPriority(t *testing.T) {
 	footer.SetWidth(120)
 
 	// Flash message should take priority over multi-select bindings
-	footer.SetContext(true, true, false, false, false, false, false, true, false)
+	footer.SetContext(true, true, false, false, false, false, false, true, false, false)
 	footer.SetFlash("Error occurred", FlashError)
 
 	view := footer.View()
@@ -260,5 +260,30 @@ func TestFooter_MultiSelectMode_FlashTakesPriority(t *testing.T) {
 	}
 	if strings.Contains(view, "toggle") {
 		t.Error("Multi-select bindings should not show when flash is active")
+	}
+}
+
+func TestFooter_NewlineShortcutDisplay(t *testing.T) {
+	footer := NewFooter()
+	footer.SetWidth(120)
+
+	// Without kitty keyboard, should show opt+enter
+	footer.SetContext(true, false, false, false, false, false, false, false, false, false)
+	view := footer.View()
+	if !strings.Contains(view, "opt+enter") {
+		t.Error("Without kitty keyboard, should show opt+enter")
+	}
+	if strings.Contains(view, "shift+enter") {
+		t.Error("Without kitty keyboard, should not show shift+enter")
+	}
+
+	// With kitty keyboard, should show shift+enter
+	footer.SetContext(true, false, false, false, false, false, false, false, false, true)
+	view = footer.View()
+	if !strings.Contains(view, "shift+enter") {
+		t.Error("With kitty keyboard, should show shift+enter")
+	}
+	if strings.Contains(view, "opt+enter") {
+		t.Error("With kitty keyboard, should not show opt+enter")
 	}
 }


### PR DESCRIPTION
## Summary
- Detects Kitty keyboard protocol support via Bubble Tea's `KeyboardEnhancementsMsg`
- Shows "shift+enter" instead of "opt+enter" in the footer and help modal when the terminal supports key disambiguation
- Both shortcuts continue to work in all terminals; this only changes the displayed hint

## Test plan
- [x] New `TestFooter_NewlineShortcutDisplay` test covers both states
- [x] All existing tests pass
- [ ] Manual: verify footer shows "opt+enter" in a non-Kitty terminal (e.g., Terminal.app)
- [ ] Manual: verify footer shows "shift+enter" in a Kitty-protocol terminal (e.g., Ghostty, Kitty, WezTerm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)