### PR TITLE
Extract path resolution into centralized `paths` package with XDG sup…

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/logger"
+	"github.com/zhubert/plural/internal/paths"
 	"github.com/zhubert/plural/internal/process"
 	"github.com/zhubert/plural/internal/session"
 )
@@ -107,7 +108,11 @@ func runCleanWithReader(input io.Reader) error {
 			fmt.Printf("      %s\n", c.Name)
 		}
 	}
-	fmt.Println("  - All log files in ~/.plural/logs")
+	if logsDir, err := paths.LogsDir(); err == nil {
+		fmt.Printf("  - All log files in %s\n", logsDir)
+	} else {
+		fmt.Println("  - All log files")
+	}
 
 	// Confirm unless --yes flag is set
 	if !skipConfirm {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ on the same codebase.`,
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug logging (verbose output to ~/.plural/logs/plural.log)")
+	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug logging (verbose output to logs directory)")
 }
 
 func initConfig() {

--- a/internal/app/fork_context_test.go
+++ b/internal/app/fork_context_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zhubert/plural/internal/config"
 	pexec "github.com/zhubert/plural/internal/exec"
 	"github.com/zhubert/plural/internal/git"
+	"github.com/zhubert/plural/internal/paths"
 	"github.com/zhubert/plural/internal/session"
 )
 
@@ -19,6 +20,8 @@ func TestForkSessionInheritsContext(t *testing.T) {
 	// Set up a temporary home directory to avoid polluting ~/.plural/ during tests
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	paths.Reset()
+	t.Cleanup(paths.Reset)
 
 	// Create test config and repo
 	cfg := &config.Config{

--- a/internal/app/session_manager_test.go
+++ b/internal/app/session_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/git"
 	"github.com/zhubert/plural/internal/mcp"
+	"github.com/zhubert/plural/internal/paths"
 )
 
 func createTestConfig() *config.Config {
@@ -699,6 +700,8 @@ func TestCopyClaudeSessionForFork_NoSessionFileCopyFallback(t *testing.T) {
 	// Set up a temporary home directory to avoid polluting ~/.claude/ during tests
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	paths.Reset()
+	t.Cleanup(paths.Reset)
 
 	// Test case 1: No saved messages - should NOT call SetForkFromSession
 	t.Run("no_messages", func(t *testing.T) {
@@ -941,6 +944,8 @@ func TestSessionManager_SaveMessages_Error(t *testing.T) {
 	os.MkdirAll(readOnlyDir, 0500)
 	defer os.Chmod(readOnlyDir, 0700)
 	t.Setenv("HOME", readOnlyDir)
+	paths.Reset()
+	t.Cleanup(paths.Reset)
 
 	cfg := createTestConfig()
 	sm := NewSessionManager(cfg, git.NewGitService())
@@ -997,6 +1002,8 @@ func TestSessionManager_SaveRunnerMessages_Error(t *testing.T) {
 	os.MkdirAll(readOnlyDir, 0500)
 	defer os.Chmod(readOnlyDir, 0700)
 	t.Setenv("HOME", readOnlyDir)
+	paths.Reset()
+	t.Cleanup(paths.Reset)
 
 	cfg := createTestConfig()
 	sm := NewSessionManager(cfg, git.NewGitService())

--- a/internal/claude/process_manager.go
+++ b/internal/claude/process_manager.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/zhubert/plural/internal/paths"
 )
 
 // errChannelFull is returned when the response channel is full for too long.
@@ -850,15 +852,14 @@ func buildContainerRunArgs(config ProcessConfig, claudeArgs []string) containerR
 }
 
 // containerAuthDir returns the directory for storing container auth files.
-// Uses ~/.plural/ which is user-private, unlike /tmp which is world-readable.
-// Returns empty string if home directory cannot be determined (credentials
+// Uses the config directory which is user-private, unlike /tmp which is world-readable.
+// Returns empty string if the config directory cannot be determined (credentials
 // will not be written rather than falling back to an insecure location).
 func containerAuthDir() string {
-	homeDir, err := os.UserHomeDir()
+	dir, err := paths.ConfigDir()
 	if err != nil {
 		return ""
 	}
-	dir := filepath.Join(homeDir, ".plural")
 	os.MkdirAll(dir, 0700)
 	return dir
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
+
+	"github.com/zhubert/plural/internal/paths"
 )
 
 // Config holds the application configuration
@@ -39,27 +40,9 @@ type Config struct {
 	filePath string
 }
 
-// configDir returns the path to the config directory
-func configDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".plural"), nil
-}
-
-// configPath returns the path to the config file
-func configPath() (string, error) {
-	dir, err := configDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "config.json"), nil
-}
-
 // Load reads the config from disk, or creates a new one if it doesn't exist
 func Load() (*Config, error) {
-	path, err := configPath()
+	path, err := paths.ConfigFilePath()
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +168,7 @@ func (c *Config) Save() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	dir, err := configDir()
+	dir, err := paths.ConfigDir()
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/zhubert/plural/internal/paths"
 )
 
 func TestConfig_AddRepo(t *testing.T) {
@@ -1055,7 +1057,11 @@ func TestLoad_NewConfig(t *testing.T) {
 	// Save original HOME and set temp dir
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	paths.Reset()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		paths.Reset()
+	}()
 
 	// Load should create a new config when none exists
 	cfg, err := Load()
@@ -1093,7 +1099,11 @@ func TestLoad_ExistingConfig(t *testing.T) {
 	// Save original HOME and set temp dir
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	paths.Reset()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		paths.Reset()
+	}()
 
 	// Create config directory and file
 	pluralDir := filepath.Join(tmpDir, ".plural")
@@ -1155,7 +1165,11 @@ func TestLoad_InvalidJSON(t *testing.T) {
 	// Save original HOME and set temp dir
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	paths.Reset()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		paths.Reset()
+	}()
 
 	// Create config directory and invalid file
 	pluralDir := filepath.Join(tmpDir, ".plural")
@@ -1186,7 +1200,11 @@ func TestLoad_InvalidConfig(t *testing.T) {
 	// Save original HOME and set temp dir
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	paths.Reset()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		paths.Reset()
+	}()
 
 	// Create config directory and file with duplicate session IDs
 	pluralDir := filepath.Join(tmpDir, ".plural")

--- a/internal/config/messages.go
+++ b/internal/config/messages.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/zhubert/plural/internal/paths"
 )
 
 // Configuration constants
@@ -19,18 +21,9 @@ type Message struct {
 	Content string `json:"content"`
 }
 
-// sessionsDir returns the path to the sessions directory
-func sessionsDir() (string, error) {
-	dir, err := configDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "sessions"), nil
-}
-
 // SaveSessionMessages saves messages for a session (keeps last maxLines lines)
 func SaveSessionMessages(sessionID string, messages []Message, maxLines int) error {
-	dir, err := sessionsDir()
+	dir, err := paths.SessionsDir()
 	if err != nil {
 		return err
 	}
@@ -66,7 +59,7 @@ func SaveSessionMessages(sessionID string, messages []Message, maxLines int) err
 
 // LoadSessionMessages loads messages for a session
 func LoadSessionMessages(sessionID string) ([]Message, error) {
-	dir, err := sessionsDir()
+	dir, err := paths.SessionsDir()
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +83,7 @@ func LoadSessionMessages(sessionID string) ([]Message, error) {
 
 // DeleteSessionMessages deletes the messages file for a session
 func DeleteSessionMessages(sessionID string) error {
-	dir, err := sessionsDir()
+	dir, err := paths.SessionsDir()
 	if err != nil {
 		return err
 	}
@@ -106,7 +99,7 @@ func DeleteSessionMessages(sessionID string) error {
 // ClearAllSessionMessages deletes all session message files.
 // Returns the number of files deleted.
 func ClearAllSessionMessages() (int, error) {
-	dir, err := sessionsDir()
+	dir, err := paths.SessionsDir()
 	if err != nil {
 		return 0, err
 	}
@@ -137,7 +130,7 @@ func ClearAllSessionMessages() (int, error) {
 // FindOrphanedSessionMessages finds session message files that don't have
 // a matching session in the config. Returns the session IDs of orphaned files.
 func FindOrphanedSessionMessages(cfg *Config) ([]string, error) {
-	dir, err := sessionsDir()
+	dir, err := paths.SessionsDir()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/zhubert/plural/internal/paths"
 )
 
 var (
@@ -17,18 +19,9 @@ var (
 	initDone bool
 )
 
-// logsDir returns the path to the logs directory (~/.plural/logs)
-func logsDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".plural", "logs"), nil
-}
-
 // DefaultLogPath returns the default log file path for the main process
 func DefaultLogPath() (string, error) {
-	dir, err := logsDir()
+	dir, err := paths.LogsDir()
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +30,7 @@ func DefaultLogPath() (string, error) {
 
 // MCPLogPath returns the log path for an MCP session
 func MCPLogPath(sessionID string) (string, error) {
-	dir, err := logsDir()
+	dir, err := paths.LogsDir()
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +39,7 @@ func MCPLogPath(sessionID string) (string, error) {
 
 // StreamLogPath returns the log path for Claude stream messages
 func StreamLogPath(sessionID string) (string, error) {
-	dir, err := logsDir()
+	dir, err := paths.LogsDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -447,9 +447,9 @@ func TestMCPLogPath(t *testing.T) {
 		t.Errorf("MCPLogPath(%q) = %q, should contain 'mcp-test-session-123.log'", sessionID, got)
 	}
 
-	// Should be in ~/.plural/logs directory
-	if !strings.Contains(got, ".plural/logs") {
-		t.Errorf("MCPLogPath(%q) = %q, should be in .plural/logs directory", sessionID, got)
+	// Should be in a logs directory
+	if !strings.Contains(got, "/logs/") {
+		t.Errorf("MCPLogPath(%q) = %q, should be in a logs directory", sessionID, got)
 	}
 }
 
@@ -466,8 +466,8 @@ func TestStreamLogPath(t *testing.T) {
 		t.Errorf("StreamLogPath(%q) = %q, should contain 'stream-test-session-456.log'", sessionID, got)
 	}
 
-	// Should be in ~/.plural/logs directory
-	if !strings.Contains(got, ".plural/logs") {
-		t.Errorf("StreamLogPath(%q) = %q, should be in .plural/logs directory", sessionID, got)
+	// Should be in a logs directory
+	if !strings.Contains(got, "/logs/") {
+		t.Errorf("StreamLogPath(%q) = %q, should be in a logs directory", sessionID, got)
 	}
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,163 @@
+// Package paths provides centralized path resolution for Plural's data directories.
+//
+// Plural supports the XDG Base Directory Specification for organizing files:
+//
+//   - Config (XDG_CONFIG_HOME): config.json — user settings worth syncing
+//   - Data (XDG_DATA_HOME): sessions/*.json — local session history
+//   - State (XDG_STATE_HOME): logs/ — transient log files
+//
+// Resolution order:
+//  1. If ~/.plural/ exists → use legacy flat layout (all paths under ~/.plural/)
+//  2. If XDG env vars are set → use XDG layout with proper separation
+//  3. Fresh install, no XDG vars → default to ~/.plural/
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	mu       sync.Mutex
+	resolved *resolvedPaths
+)
+
+type resolvedPaths struct {
+	configDir string
+	dataDir   string
+	stateDir  string
+	legacy    bool
+}
+
+// resolve computes the path layout once and caches it.
+func resolve() (*resolvedPaths, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if resolved != nil {
+		return resolved, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	legacyDir := filepath.Join(home, ".plural")
+
+	// 1. If ~/.plural/ exists, use legacy layout
+	if info, err := os.Stat(legacyDir); err == nil && info.IsDir() {
+		resolved = &resolvedPaths{
+			configDir: legacyDir,
+			dataDir:   legacyDir,
+			stateDir:  legacyDir,
+			legacy:    true,
+		}
+		return resolved, nil
+	}
+
+	// 2. Check XDG env vars
+	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+	xdgData := os.Getenv("XDG_DATA_HOME")
+	xdgState := os.Getenv("XDG_STATE_HOME")
+
+	if xdgConfig != "" || xdgData != "" || xdgState != "" {
+		// Use XDG layout — fill in defaults for unset vars
+		if xdgConfig == "" {
+			xdgConfig = filepath.Join(home, ".config")
+		}
+		if xdgData == "" {
+			xdgData = filepath.Join(home, ".local", "share")
+		}
+		if xdgState == "" {
+			xdgState = filepath.Join(home, ".local", "state")
+		}
+		resolved = &resolvedPaths{
+			configDir: filepath.Join(xdgConfig, "plural"),
+			dataDir:   filepath.Join(xdgData, "plural"),
+			stateDir:  filepath.Join(xdgState, "plural"),
+			legacy:    false,
+		}
+		return resolved, nil
+	}
+
+	// 3. Fresh install, no XDG — default to legacy
+	resolved = &resolvedPaths{
+		configDir: legacyDir,
+		dataDir:   legacyDir,
+		stateDir:  legacyDir,
+		legacy:    true,
+	}
+	return resolved, nil
+}
+
+// ConfigDir returns the directory for configuration files (config.json).
+func ConfigDir() (string, error) {
+	r, err := resolve()
+	if err != nil {
+		return "", err
+	}
+	return r.configDir, nil
+}
+
+// DataDir returns the directory for persistent data files.
+func DataDir() (string, error) {
+	r, err := resolve()
+	if err != nil {
+		return "", err
+	}
+	return r.dataDir, nil
+}
+
+// StateDir returns the directory for runtime state and logs.
+func StateDir() (string, error) {
+	r, err := resolve()
+	if err != nil {
+		return "", err
+	}
+	return r.stateDir, nil
+}
+
+// ConfigFilePath returns the full path to config.json.
+func ConfigFilePath() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.json"), nil
+}
+
+// SessionsDir returns the directory for session message files.
+func SessionsDir() (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "sessions"), nil
+}
+
+// LogsDir returns the directory for log files.
+func LogsDir() (string, error) {
+	dir, err := StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "logs"), nil
+}
+
+// IsLegacyLayout returns true if using the ~/.plural/ flat layout.
+func IsLegacyLayout() bool {
+	r, err := resolve()
+	if err != nil {
+		return true // assume legacy on error
+	}
+	return r.legacy
+}
+
+// Reset clears the cached path resolution. This is intended for testing only.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	resolved = nil
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,317 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestHome creates a temp directory, sets HOME to it, and resets the path cache.
+// Returns the temp home path and a cleanup function.
+func setupTestHome(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	Reset()
+	t.Cleanup(Reset)
+	return tmpDir
+}
+
+func TestFreshInstallNoXDG(t *testing.T) {
+	home := setupTestHome(t)
+	// No ~/.plural/, no XDG vars → default to ~/.plural/
+	expected := filepath.Join(home, ".plural")
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if configDir != expected {
+		t.Errorf("ConfigDir = %q, want %q", configDir, expected)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if dataDir != expected {
+		t.Errorf("DataDir = %q, want %q", dataDir, expected)
+	}
+
+	stateDir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir: %v", err)
+	}
+	if stateDir != expected {
+		t.Errorf("StateDir = %q, want %q", stateDir, expected)
+	}
+
+	if !IsLegacyLayout() {
+		t.Error("IsLegacyLayout should be true for fresh install without XDG")
+	}
+}
+
+func TestLegacyDirExists(t *testing.T) {
+	home := setupTestHome(t)
+	legacyDir := filepath.Join(home, ".plural")
+	if err := os.MkdirAll(legacyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if configDir != legacyDir {
+		t.Errorf("ConfigDir = %q, want %q", configDir, legacyDir)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if dataDir != legacyDir {
+		t.Errorf("DataDir = %q, want %q", dataDir, legacyDir)
+	}
+
+	stateDir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir: %v", err)
+	}
+	if stateDir != legacyDir {
+		t.Errorf("StateDir = %q, want %q", stateDir, legacyDir)
+	}
+
+	if !IsLegacyLayout() {
+		t.Error("IsLegacyLayout should be true when ~/.plural/ exists")
+	}
+}
+
+func TestLegacyTakesPrecedenceOverXDG(t *testing.T) {
+	home := setupTestHome(t)
+	legacyDir := filepath.Join(home, ".plural")
+	if err := os.MkdirAll(legacyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set XDG vars — legacy should still win
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	Reset()
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if configDir != legacyDir {
+		t.Errorf("ConfigDir = %q, want %q (legacy should take precedence)", configDir, legacyDir)
+	}
+
+	if !IsLegacyLayout() {
+		t.Error("IsLegacyLayout should be true when ~/.plural/ exists, even with XDG vars")
+	}
+}
+
+func TestXDGAllVarsSet(t *testing.T) {
+	home := setupTestHome(t)
+	// No ~/.plural/ exists
+
+	xdgConfig := filepath.Join(home, "my-config")
+	xdgData := filepath.Join(home, "my-data")
+	xdgState := filepath.Join(home, "my-state")
+
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	t.Setenv("XDG_DATA_HOME", xdgData)
+	t.Setenv("XDG_STATE_HOME", xdgState)
+	Reset()
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if want := filepath.Join(xdgConfig, "plural"); configDir != want {
+		t.Errorf("ConfigDir = %q, want %q", configDir, want)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if want := filepath.Join(xdgData, "plural"); dataDir != want {
+		t.Errorf("DataDir = %q, want %q", dataDir, want)
+	}
+
+	stateDir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir: %v", err)
+	}
+	if want := filepath.Join(xdgState, "plural"); stateDir != want {
+		t.Errorf("StateDir = %q, want %q", stateDir, want)
+	}
+
+	if IsLegacyLayout() {
+		t.Error("IsLegacyLayout should be false when using XDG")
+	}
+}
+
+func TestXDGPartialVars(t *testing.T) {
+	home := setupTestHome(t)
+	// No ~/.plural/ exists
+
+	xdgConfig := filepath.Join(home, "my-config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	// XDG_DATA_HOME and XDG_STATE_HOME not set — should use XDG defaults
+	Reset()
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if want := filepath.Join(xdgConfig, "plural"); configDir != want {
+		t.Errorf("ConfigDir = %q, want %q", configDir, want)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if want := filepath.Join(home, ".local", "share", "plural"); dataDir != want {
+		t.Errorf("DataDir = %q, want %q", dataDir, want)
+	}
+
+	stateDir, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir: %v", err)
+	}
+	if want := filepath.Join(home, ".local", "state", "plural"); stateDir != want {
+		t.Errorf("StateDir = %q, want %q", stateDir, want)
+	}
+
+	if IsLegacyLayout() {
+		t.Error("IsLegacyLayout should be false when using XDG")
+	}
+}
+
+func TestDerivedPaths(t *testing.T) {
+	home := setupTestHome(t)
+	legacyDir := filepath.Join(home, ".plural")
+	if err := os.MkdirAll(legacyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("legacy layout", func(t *testing.T) {
+		Reset()
+		cfgPath, err := ConfigFilePath()
+		if err != nil {
+			t.Fatalf("ConfigFilePath: %v", err)
+		}
+		if want := filepath.Join(legacyDir, "config.json"); cfgPath != want {
+			t.Errorf("ConfigFilePath = %q, want %q", cfgPath, want)
+		}
+
+		sessDir, err := SessionsDir()
+		if err != nil {
+			t.Fatalf("SessionsDir: %v", err)
+		}
+		if want := filepath.Join(legacyDir, "sessions"); sessDir != want {
+			t.Errorf("SessionsDir = %q, want %q", sessDir, want)
+		}
+
+		logsDir, err := LogsDir()
+		if err != nil {
+			t.Fatalf("LogsDir: %v", err)
+		}
+		if want := filepath.Join(legacyDir, "logs"); logsDir != want {
+			t.Errorf("LogsDir = %q, want %q", logsDir, want)
+		}
+	})
+
+	t.Run("XDG layout", func(t *testing.T) {
+		// Remove legacy dir so XDG kicks in
+		os.RemoveAll(legacyDir)
+		xdgConfig := filepath.Join(home, ".config")
+		xdgData := filepath.Join(home, ".local", "share")
+		xdgState := filepath.Join(home, ".local", "state")
+		t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+		t.Setenv("XDG_DATA_HOME", xdgData)
+		t.Setenv("XDG_STATE_HOME", xdgState)
+		Reset()
+
+		cfgPath, err := ConfigFilePath()
+		if err != nil {
+			t.Fatalf("ConfigFilePath: %v", err)
+		}
+		if want := filepath.Join(xdgConfig, "plural", "config.json"); cfgPath != want {
+			t.Errorf("ConfigFilePath = %q, want %q", cfgPath, want)
+		}
+
+		sessDir, err := SessionsDir()
+		if err != nil {
+			t.Fatalf("SessionsDir: %v", err)
+		}
+		if want := filepath.Join(xdgData, "plural", "sessions"); sessDir != want {
+			t.Errorf("SessionsDir = %q, want %q", sessDir, want)
+		}
+
+		logsDir, err := LogsDir()
+		if err != nil {
+			t.Fatalf("LogsDir: %v", err)
+		}
+		if want := filepath.Join(xdgState, "plural", "logs"); logsDir != want {
+			t.Errorf("LogsDir = %q, want %q", logsDir, want)
+		}
+	})
+}
+
+func TestResetClearsCache(t *testing.T) {
+	home := setupTestHome(t)
+
+	// First resolve: no legacy, no XDG → defaults to ~/.plural/
+	dir1, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	expectedLegacy := filepath.Join(home, ".plural")
+	if dir1 != expectedLegacy {
+		t.Errorf("ConfigDir = %q, want %q", dir1, expectedLegacy)
+	}
+
+	// Now set XDG and reset
+	xdgConfig := filepath.Join(home, "new-config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	Reset()
+
+	dir2, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir after reset: %v", err)
+	}
+	expectedXDG := filepath.Join(xdgConfig, "plural")
+	if dir2 != expectedXDG {
+		t.Errorf("ConfigDir after reset = %q, want %q", dir2, expectedXDG)
+	}
+}
+
+func TestLegacyFileNotDir(t *testing.T) {
+	home := setupTestHome(t)
+	// Create ~/.plural as a file, not a directory — should NOT be treated as legacy
+	legacyPath := filepath.Join(home, ".plural")
+	if err := os.WriteFile(legacyPath, []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	xdgConfig := filepath.Join(home, ".config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	Reset()
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if want := filepath.Join(xdgConfig, "plural"); configDir != want {
+		t.Errorf("ConfigDir = %q, want %q (file named .plural should not trigger legacy)", configDir, want)
+	}
+}


### PR DESCRIPTION
…port

Consolidate scattered `configDir()`, `sessionsDir()`, `logsDir()` helpers from config, logger, and process_manager into a single `internal/paths` package. This enables XDG Base Directory support for new installs while preserving the `~/.plural/` layout for existing users. Path resolution is cached and includes a `Reset()` for testability.