### PR TITLE
fix(claude): prevent race condition on streamLogFile between handleProcessLine and Stop

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -2975,4 +2977,43 @@ func TestTokenTracking_NoRaceCondition(t *testing.T) {
 
 	<-done
 	close(ch)
+}
+
+func TestRunner_StreamLogFile_NoRaceWithStop(t *testing.T) {
+	// This test verifies that concurrent calls to handleProcessLine and Stop
+	// do not race on r.streamLogFile. Run with -race to detect the issue.
+	runner := New("race-test", "/tmp", false, nil)
+
+	// Set a stream log file (use a temp file so writes succeed)
+	tmpFile, err := os.CreateTemp("", "stream-log-race-test-*.log")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	runner.mu.Lock()
+	runner.streamLogFile = tmpFile
+	runner.mu.Unlock()
+
+	line := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`
+
+	// Run handleProcessLine and Stop concurrently to trigger the race.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			runner.handleProcessLine(line)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		// Give handleProcessLine a head start so calls overlap
+		time.Sleep(time.Millisecond)
+		runner.Stop()
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
Fix a data race where `handleProcessLine` and `Stop` could concurrently access `r.streamLogFile`, with `Stop` closing and nilling the file while `handleProcessLine` was still writing to it.

## Changes
- Snapshot `r.streamLogFile` under a read lock in `handleProcessLine` to avoid racing with `Stop()`, which sets it to nil after closing
- Add regression test that exercises concurrent `handleProcessLine` and `Stop` calls (detectable with `-race`)

## Test plan
- Run `go test -race ./internal/claude/...` to verify no data race is reported
- Run full test suite with `go test ./...`

Fixes #127