### PR TITLE
refactor(claude): extract channel sends into safeSendChannel to prevent panics

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -1749,6 +1749,114 @@ func TestHandleFatalError_NilChannel(t *testing.T) {
 	runner.handleFatalError(fmt.Errorf("test error"))
 }
 
+func TestHandleProcessExit_AlreadyMarkedClosed(t *testing.T) {
+	runner := New("session-1", "/tmp", false, nil)
+
+	ch := make(chan ResponseChunk, 10)
+	runner.mu.Lock()
+	runner.responseChan.Setup(ch)
+	runner.responseChan.Closed = true
+	runner.mu.Unlock()
+
+	// Should not send anything since channel is marked closed
+	shouldRestart := runner.handleProcessExit(fmt.Errorf("crash"), "stderr output")
+	if !shouldRestart {
+		t.Error("Expected handleProcessExit to return true (should restart)")
+	}
+
+	select {
+	case <-ch:
+		t.Error("Should not receive chunk when channel is marked closed")
+	default:
+		// Expected
+	}
+}
+
+func TestHandleProcessExit_NormalSend(t *testing.T) {
+	runner := New("session-1", "/tmp", false, nil)
+
+	ch := make(chan ResponseChunk, 10)
+	runner.mu.Lock()
+	runner.responseChan.Setup(ch)
+	runner.mu.Unlock()
+
+	shouldRestart := runner.handleProcessExit(fmt.Errorf("crash"), "stderr output")
+	if !shouldRestart {
+		t.Error("Expected handleProcessExit to return true")
+	}
+
+	// Should receive a Done chunk
+	select {
+	case chunk := <-ch:
+		if !chunk.Done {
+			t.Error("Expected Done=true in chunk")
+		}
+	default:
+		t.Error("Expected chunk from channel")
+	}
+
+	// Channel should be closed
+	runner.mu.RLock()
+	closed := runner.responseChan.Closed
+	runner.mu.RUnlock()
+	if !closed {
+		t.Error("Expected responseChan.Closed to be true")
+	}
+}
+
+func TestHandleProcessExit_Stopped(t *testing.T) {
+	runner := New("session-1", "/tmp", false, nil)
+
+	runner.mu.Lock()
+	runner.stopped = true
+	runner.mu.Unlock()
+
+	shouldRestart := runner.handleProcessExit(fmt.Errorf("crash"), "stderr")
+	if shouldRestart {
+		t.Error("Expected handleProcessExit to return false when stopped")
+	}
+}
+
+func TestHandleRestartAttempt_ClosedChannel(t *testing.T) {
+	runner := New("session-1", "/tmp", false, nil)
+
+	ch := make(chan ResponseChunk, 10)
+	runner.mu.Lock()
+	runner.responseChan.Setup(ch)
+	runner.mu.Unlock()
+
+	// Close the underlying channel without updating Closed flag to simulate
+	// the race where Stop() closes the channel between the flag check and the send.
+	close(ch)
+
+	// Should not panic thanks to safeSendChannel
+	runner.handleRestartAttempt(1)
+}
+
+func TestHandleRestartAttempt_NormalSend(t *testing.T) {
+	runner := New("session-1", "/tmp", false, nil)
+
+	ch := make(chan ResponseChunk, 10)
+	runner.mu.Lock()
+	runner.responseChan.Setup(ch)
+	runner.mu.Unlock()
+
+	runner.handleRestartAttempt(2)
+
+	select {
+	case chunk := <-ch:
+		if chunk.Type != ChunkTypeText {
+			t.Errorf("Expected ChunkTypeText, got %v", chunk.Type)
+		}
+		expected := "\n[Process crashed, attempting restart 2/3...]\n"
+		if chunk.Content != expected {
+			t.Errorf("Expected %q, got %q", expected, chunk.Content)
+		}
+	default:
+		t.Error("Expected chunk from channel")
+	}
+}
+
 func TestErrorVariables(t *testing.T) {
 	// Verify error variables are defined
 	if errChannelFull == nil {


### PR DESCRIPTION
## Summary
Extracts repeated `select { case ch <- ...: default: }` channel send patterns into a `safeSendChannel` helper function that also recovers from panics when sending on a closed channel, preventing crashes from race conditions between `Stop()` and process exit handlers.

## Changes
- Replace inline `select`/`default` channel sends in `handleProcessExit`, `handleRestartAttempt`, and `handleFatalError` with calls to `safeSendChannel`
- Add tests for `handleProcessExit` covering normal send, already-closed flag, and stopped runner scenarios
- Add tests for `handleRestartAttempt` covering normal send and closed-channel panic recovery

## Test plan
- `go test ./internal/claude/...` — all new and existing tests pass
- New tests verify `safeSendChannel` prevents panics when the underlying channel is closed between the flag check and the send

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #129