### PR TITLE
Fix container auth: switch from volume mount to --env-file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,8 +514,8 @@ Sessions can optionally run Claude CLI inside Docker containers with `--dangerou
 - `Start()`: When containerized, checks `ContainerAuthAvailable()` first, then builds command as `docker run -i --rm ...` wrapping `claude`
 - `Stop()`: Runs `docker rm -f` as defense-in-depth cleanup
 - `ContainerAuthAvailable()`: Checks if credentials exist (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or keychain)
-- `buildContainerRunArgs()`: Constructs `docker run` arguments with `--add-host host.docker.internal:host-gateway`, worktree mount, auth mount, MCP config mount, working directory
-- `writeContainerAuthFile()`: Writes credentials to temp file for container mount (API key, OAuth token, or keychain)
+- `buildContainerRunArgs()`: Constructs `docker run` arguments with `--add-host host.docker.internal:host-gateway`, worktree mount, `--env-file` for auth, MCP config mount, working directory
+- `writeContainerAuthFile()`: Writes credentials to temp file in Docker env-file format for `--env-file` flag (API key, OAuth token, or keychain)
 
 **Runner** (`internal/claude/claude.go`):
 - `SetContainerized(bool, string)`: Stores container mode and image

--- a/entrypoint-claude.sh
+++ b/entrypoint-claude.sh
@@ -29,15 +29,4 @@ if command -v gopls >/dev/null 2>&1 && [ ! -f "$DEST_DIR/plugins/gopls/plugin.js
 EOF
 fi
 
-# Read auth credentials from mounted secrets file (not passed via -e to
-# avoid exposing the key in `ps` output on the host).
-# File format: ANTHROPIC_API_KEY='value' or CLAUDE_CODE_OAUTH_TOKEN='value'
-# Uses set -a to auto-export all variables, then sources the file.
-# This is safer than export "$(cat ...)" which breaks on newlines.
-if [ -f /home/claude/.auth ]; then
-    set -a
-    . /home/claude/.auth
-    set +a
-fi
-
 exec claude "$@"


### PR DESCRIPTION
## Summary
- Container sessions were hanging at "Starting container..." because the entrypoint's shell sourcing (`set -a; . /home/claude/.auth; set +a`) wasn't successfully setting env vars for Claude CLI (`apiKeySource: "none"`)
- Switched from mounting auth as a file (`-v auth:/home/claude/.auth:ro`) to Docker's `--env-file` flag, which sets env vars directly in the container process
- Auth file format changed from shell syntax (`KEY='value'`) to Docker env-file format (`KEY=value`)

## Test plan
- [x] `go test ./internal/claude/... -run TestWriteContainerAuthFile` — auth file format tests pass
- [x] `go test ./internal/claude/... -run TestBuildContainerRunArgs` — docker args tests pass
- [x] `go test ./...` — full test suite passes
- [ ] Manual: create a containerized session and verify it starts successfully (no more "Starting container..." hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)