### PR TITLE
fix(ui): wrap plan box content to capped box width instead of viewport width

### DIFF
--- a/internal/ui/chat.go
+++ b/internal/ui/chat.go
@@ -1082,13 +1082,19 @@ func (c *Chat) renderPlanApprovalPrompt(wrapWidth int) string {
 
 	var sb strings.Builder
 
+	// Calculate final box width first (capped at max width for readability)
+	boxWidth := wrapWidth
+	if boxWidth > PlanBoxMaxWidth {
+		boxWidth = PlanBoxMaxWidth
+	}
+
 	// Title
 	titleStyle := lipgloss.NewStyle().Foreground(ColorInfo).Bold(true)
 	sb.WriteString(titleStyle.Render("Plan Approval Required"))
 	sb.WriteString("\n\n")
 
-	// Render plan as markdown, accounting for box padding
-	renderedPlan := renderMarkdown(c.planApproval.Plan, wrapWidth-OverlayBoxPadding)
+	// Render plan as markdown, accounting for box padding, using final box width
+	renderedPlan := renderMarkdown(c.planApproval.Plan, boxWidth-OverlayBoxPadding)
 	planLines := strings.Split(renderedPlan, "\n")
 	maxVisibleLines := PlanApprovalMaxVisible
 
@@ -1153,12 +1159,6 @@ func (c *Chat) renderPlanApprovalPrompt(wrapWidth int) string {
 		sb.WriteString(hintStyle.Render(" Scroll"))
 	}
 
-	// Wrap in a box, capped at max width for readability
-	// Plans use a wider max since they often contain code
-	boxWidth := wrapWidth
-	if boxWidth > PlanBoxMaxWidth {
-		boxWidth = PlanBoxMaxWidth
-	}
 	return PlanApprovalBoxStyle.Width(boxWidth).Render(sb.String())
 }
 


### PR DESCRIPTION
## Summary
Fix plan approval box content overflowing its border when the terminal is wider than `PlanBoxMaxWidth`.

## Changes
- Move the box width capping logic before the markdown rendering call so content wraps to the capped width rather than the full viewport width
- Previously, content was wrapped to `wrapWidth - OverlayBoxPadding` but the box itself was capped at `PlanBoxMaxWidth`, causing long lines to overflow the box border on wide terminals
- Add regression test `TestPlanBoxContentWrapsToBoxWidth` that verifies no line exceeds the capped box width

## Test plan
- Run `go test ./internal/ui/ -run TestPlanBox` to verify both the existing width capping test and the new content wrapping regression test pass
- Manually test with a wide terminal (>100 columns): open a plan approval prompt with long content and confirm text wraps within the box borders