### PR TITLE
feat: add PR review comments import feature

### DIFF
--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -51,6 +51,8 @@ func (m *Model) handleModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleEditCommitModal(key, msg, s)
 	case *ui.MergeConflictState:
 		return m.handleMergeConflictModal(key, msg, s)
+	case *ui.ReviewCommentsState:
+		return m.handleReviewCommentsModal(key, msg, s)
 
 	// Workspace modals (modal_handlers_config.go)
 	case *ui.WorkspaceListState:

--- a/internal/app/msg_handlers.go
+++ b/internal/app/msg_handlers.go
@@ -550,6 +550,30 @@ func (m *Model) handleIssuesFetchedMsg(msg IssuesFetchedMsg) (tea.Model, tea.Cmd
 	return m, nil
 }
 
+// handleReviewCommentsFetchedMsg handles fetched PR review comments.
+func (m *Model) handleReviewCommentsFetchedMsg(msg ReviewCommentsFetchedMsg) (tea.Model, tea.Cmd) {
+	if state, ok := m.modal.State.(*ui.ReviewCommentsState); ok {
+		if msg.Error != nil {
+			state.SetError(msg.Error.Error())
+		} else {
+			// Convert git.PRReviewComment to ui.ReviewCommentItem
+			items := make([]ui.ReviewCommentItem, len(msg.Comments))
+			for i, c := range msg.Comments {
+				items[i] = ui.ReviewCommentItem{
+					Author:   c.Author,
+					Body:     c.Body,
+					Path:     c.Path,
+					Line:     c.Line,
+					URL:      c.URL,
+					Selected: true, // Pre-select all comments by default
+				}
+			}
+			state.SetComments(items)
+		}
+	}
+	return m, nil
+}
+
 // handlePRBatchStatusCheckMsg handles the batch result of checking all eligible sessions' PR states.
 func (m *Model) handlePRBatchStatusCheckMsg(msg PRBatchStatusCheckMsg) (tea.Model, tea.Cmd) {
 	if msg.Error != nil {

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -184,6 +184,15 @@ var ShortcutRegistry = []Shortcut{
 		RequiresSession: true,
 		Handler:         shortcutPreviewInMain,
 	},
+	{
+		Key:             keys.CtrlR,
+		DisplayKey:      "ctrl-r",
+		Description:     "Import PR review comments",
+		Category:        CategoryGit,
+		RequiresSession: true,
+		RequiresSidebar: true,
+		Handler:         shortcutReviewComments,
+	},
 
 	// Configuration
 	{
@@ -695,6 +704,17 @@ func shortcutToggleLogViewer(m *Model) (tea.Model, tea.Cmd) {
 	m.chat.SetFocused(true)
 
 	return m, nil
+}
+
+func shortcutReviewComments(m *Model) (tea.Model, tea.Cmd) {
+	sess := m.sidebar.SelectedSession()
+	// Select the session if not already active
+	if m.activeSession == nil || m.activeSession.ID != sess.ID {
+		m.selectSession(sess)
+	}
+	// Show the review comments modal in loading state
+	m.modal.Show(ui.NewReviewCommentsState(sess.ID, sess.Branch))
+	return m, m.fetchReviewComments(sess.ID, sess.RepoPath, sess.Branch)
 }
 
 func shortcutPreviewInMain(m *Model) (tea.Model, tea.Cmd) {

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -49,6 +49,7 @@ var (
 	CtrlN      = (tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}).String()                      // "ctrl+n"
 	CtrlP      = (tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl}).String()                      // "ctrl+p"
 	CtrlE      = (tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl}).String()                      // "ctrl+e"
+	CtrlR      = (tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}).String()                      // "ctrl+r"
 	CtrlSlash  = (tea.KeyPressMsg{Code: '/', Mod: tea.ModCtrl}).String()                      // "ctrl+/"
 	CtrlShiftB = (tea.KeyPressMsg{Code: 'b', Mod: tea.ModCtrl | tea.ModShift}).String()       // "ctrl+shift+b"
 	CtrlUp     = (tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModCtrl}).String()                // "ctrl+up"

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -23,6 +23,7 @@ type (
 	HelpSection              = modals.HelpSection
 	SearchResult             = modals.SearchResult
 	RepoItem                 = modals.RepoItem
+	ReviewCommentItem        = modals.ReviewCommentItem
 
 	AddRepoState             = modals.AddRepoState
 	SelectRepoForIssuesState = modals.SelectRepoForIssuesState
@@ -58,6 +59,7 @@ type (
 	NewWorkspaceState        = modals.NewWorkspaceState
 	BulkActionState          = modals.BulkActionState
 	BulkAction               = modals.BulkAction
+	ReviewCommentsState      = modals.ReviewCommentsState
 	ContainerBuildState      = modals.ContainerBuildState
 	ContainerCommandState    = modals.ContainerCommandState
 	AsanaProjectOption       = modals.AsanaProjectOption
@@ -113,6 +115,7 @@ var (
 	NewWorkspaceListState      = modals.NewWorkspaceListState
 	NewNewWorkspaceState       = modals.NewNewWorkspaceState
 	NewRenameWorkspaceState    = modals.NewRenameWorkspaceState
+	NewReviewCommentsState             = modals.NewReviewCommentsState
 	NewContainerBuildState             = modals.NewContainerBuildState
 	NewContainerCLINotInstalledState   = modals.NewContainerCLINotInstalledState
 	NewContainerSystemNotRunningState  = modals.NewContainerSystemNotRunningState

--- a/internal/ui/modals/review_comments.go
+++ b/internal/ui/modals/review_comments.go
@@ -1,0 +1,263 @@
+package modals
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/zhubert/plural/internal/keys"
+)
+
+// ReviewCommentsState holds state for the PR Review Comments modal.
+type ReviewCommentsState struct {
+	SessionID     string
+	Branch        string
+	Comments      []ReviewCommentItem
+	SelectedIndex int
+	Loading       bool
+	LoadError     string
+	ScrollOffset  int
+	maxVisible    int
+
+	// Size tracking
+	availableWidth int
+}
+
+func (*ReviewCommentsState) modalState() {}
+
+// PreferredWidth returns the preferred width for this modal.
+func (s *ReviewCommentsState) PreferredWidth() int {
+	return ModalWidthWide
+}
+
+// SetSize updates the available width for rendering content.
+func (s *ReviewCommentsState) SetSize(width, height int) {
+	s.availableWidth = width
+}
+
+func (s *ReviewCommentsState) Title() string {
+	return "PR Review Comments"
+}
+
+func (s *ReviewCommentsState) Help() string {
+	if s.Loading {
+		return "Loading review comments..."
+	}
+	if s.LoadError != "" {
+		return "Esc: close"
+	}
+	return "up/down navigate  Space: toggle  a: select all  Enter: send to Claude  Esc: cancel"
+}
+
+func (s *ReviewCommentsState) Render() string {
+	title := ModalTitleStyle.Render(s.Title())
+
+	branchLabel := lipgloss.NewStyle().
+		Foreground(ColorTextMuted).
+		Render("Branch:")
+
+	branchName := lipgloss.NewStyle().
+		Foreground(ColorSecondary).
+		Bold(true).
+		MarginBottom(1).
+		Render("  " + s.Branch)
+
+	// Loading state
+	if s.Loading {
+		loadingText := lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("Fetching review comments...")
+		help := ModalHelpStyle.Render(s.Help())
+		return lipgloss.JoinVertical(lipgloss.Left, title, branchLabel, branchName, loadingText, help)
+	}
+
+	// Error state
+	if s.LoadError != "" {
+		errorText := StatusErrorStyle.Render(s.LoadError)
+		help := ModalHelpStyle.Render(s.Help())
+		return lipgloss.JoinVertical(lipgloss.Left, title, branchLabel, branchName, errorText, help)
+	}
+
+	// No comments
+	if len(s.Comments) == 0 {
+		noComments := lipgloss.NewStyle().
+			Foreground(ColorTextMuted).
+			Italic(true).
+			Render("No review comments found")
+		help := ModalHelpStyle.Render(s.Help())
+		return lipgloss.JoinVertical(lipgloss.Left, title, branchLabel, branchName, noComments, help)
+	}
+
+	description := lipgloss.NewStyle().
+		Foreground(ColorTextMuted).
+		MarginBottom(1).
+		Render("Select comments to address:")
+
+	// Build comment list with scrolling
+	modalWidth := s.availableWidth
+	if modalWidth == 0 {
+		modalWidth = s.PreferredWidth()
+	}
+	contentWidth := modalWidth - 4 // Account for modal padding/borders
+
+	var commentList string
+	visibleEnd := s.ScrollOffset + s.maxVisible
+	if visibleEnd > len(s.Comments) {
+		visibleEnd = len(s.Comments)
+	}
+
+	for i := s.ScrollOffset; i < visibleEnd; i++ {
+		comment := s.Comments[i]
+		style := SidebarItemStyle
+		prefix := "  "
+		checkbox := "[ ]"
+
+		if i == s.SelectedIndex {
+			style = SidebarSelectedStyle
+			prefix = "> "
+		}
+
+		if comment.Selected {
+			checkbox = "[x]"
+		}
+
+		// First line: checkbox + author + optional file path
+		var headerParts []string
+		if comment.Author != "" {
+			headerParts = append(headerParts, "@"+comment.Author)
+		}
+		if comment.Path != "" {
+			if comment.Line > 0 {
+				headerParts = append(headerParts, fmt.Sprintf("%s:%d", comment.Path, comment.Line))
+			} else {
+				headerParts = append(headerParts, comment.Path)
+			}
+		}
+
+		headerLine := fmt.Sprintf("%s %s", checkbox, strings.Join(headerParts, "  "))
+		commentList += style.Render(prefix+headerLine) + "\n"
+
+		// Second line: truncated body (indented to align with header text)
+		bodyText := strings.TrimSpace(comment.Body)
+		// Replace newlines with spaces for compact display
+		bodyText = strings.ReplaceAll(bodyText, "\n", " ")
+		// Truncate body to fit in available width
+		// Overhead: "  " prefix + "      " indent = 8 chars
+		maxBodyLen := contentWidth - 8
+		if maxBodyLen < 10 {
+			maxBodyLen = 10
+		}
+		bodyRunes := []rune(bodyText)
+		if len(bodyRunes) > maxBodyLen {
+			bodyText = string(bodyRunes[:maxBodyLen-3]) + "..."
+		}
+
+		bodyStyle := lipgloss.NewStyle().Foreground(ColorTextMuted)
+		indent := "      " // Align with text after checkbox
+		commentList += bodyStyle.Render(prefix+indent+bodyText) + "\n"
+	}
+
+	// Scroll indicators
+	if s.ScrollOffset > 0 {
+		commentList = lipgloss.NewStyle().Foreground(ColorTextMuted).Render("  up more above\n") + commentList
+	}
+	if visibleEnd < len(s.Comments) {
+		commentList += lipgloss.NewStyle().Foreground(ColorTextMuted).Render("  down more below\n")
+	}
+
+	// Show count of selected comments
+	selectedCount := 0
+	for _, c := range s.Comments {
+		if c.Selected {
+			selectedCount++
+		}
+	}
+
+	countStyle := lipgloss.NewStyle().
+		Foreground(ColorSecondary).
+		MarginTop(1)
+	countText := fmt.Sprintf("%d of %d comment(s) selected", selectedCount, len(s.Comments))
+	countSection := countStyle.Render(countText)
+
+	help := ModalHelpStyle.Render(s.Help())
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, branchLabel, branchName, description, commentList, countSection, help)
+}
+
+func (s *ReviewCommentsState) Update(msg tea.Msg) (ModalState, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		switch keyMsg.String() {
+		case keys.Up, "k":
+			if s.SelectedIndex > 0 {
+				s.SelectedIndex--
+				if s.SelectedIndex < s.ScrollOffset {
+					s.ScrollOffset = s.SelectedIndex
+				}
+			}
+		case keys.Down, "j":
+			if s.SelectedIndex < len(s.Comments)-1 {
+				s.SelectedIndex++
+				if s.SelectedIndex >= s.ScrollOffset+s.maxVisible {
+					s.ScrollOffset = s.SelectedIndex - s.maxVisible + 1
+				}
+			}
+		case keys.Space:
+			if s.SelectedIndex < len(s.Comments) {
+				s.Comments[s.SelectedIndex].Selected = !s.Comments[s.SelectedIndex].Selected
+			}
+		case "a":
+			// Toggle select all: if all are selected, deselect all; otherwise select all
+			allSelected := true
+			for _, c := range s.Comments {
+				if !c.Selected {
+					allSelected = false
+					break
+				}
+			}
+			for i := range s.Comments {
+				s.Comments[i].Selected = !allSelected
+			}
+		}
+	}
+	return s, nil
+}
+
+// GetSelectedComments returns the comments that are selected.
+func (s *ReviewCommentsState) GetSelectedComments() []ReviewCommentItem {
+	var selected []ReviewCommentItem
+	for _, c := range s.Comments {
+		if c.Selected {
+			selected = append(selected, c)
+		}
+	}
+	return selected
+}
+
+// SetComments sets the comments list and clears loading state.
+func (s *ReviewCommentsState) SetComments(comments []ReviewCommentItem) {
+	s.Comments = comments
+	s.Loading = false
+	s.LoadError = ""
+}
+
+// SetError sets an error and clears loading state.
+func (s *ReviewCommentsState) SetError(err string) {
+	s.LoadError = err
+	s.Loading = false
+}
+
+// NewReviewCommentsState creates a new ReviewCommentsState in loading state.
+func NewReviewCommentsState(sessionID, branch string) *ReviewCommentsState {
+	return &ReviewCommentsState{
+		SessionID:      sessionID,
+		Branch:         branch,
+		Loading:        true,
+		SelectedIndex:  0,
+		ScrollOffset:   0,
+		maxVisible:     IssuesModalMaxVisible,
+		availableWidth: ModalWidthWide,
+	}
+}

--- a/internal/ui/modals/review_comments_test.go
+++ b/internal/ui/modals/review_comments_test.go
@@ -1,0 +1,332 @@
+package modals
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// =============================================================================
+// ReviewCommentsState Tests
+// =============================================================================
+
+func TestNewReviewCommentsState(t *testing.T) {
+	state := NewReviewCommentsState("session-123", "feature-branch")
+
+	if state.SessionID != "session-123" {
+		t.Errorf("expected session ID 'session-123', got '%s'", state.SessionID)
+	}
+	if state.Branch != "feature-branch" {
+		t.Errorf("expected branch 'feature-branch', got '%s'", state.Branch)
+	}
+	if !state.Loading {
+		t.Error("expected Loading to be true initially")
+	}
+	if state.SelectedIndex != 0 {
+		t.Errorf("expected initial selected index 0, got %d", state.SelectedIndex)
+	}
+	if state.LoadError != "" {
+		t.Errorf("expected empty load error, got '%s'", state.LoadError)
+	}
+}
+
+func TestReviewCommentsState_Title(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	if state.Title() != "PR Review Comments" {
+		t.Errorf("expected title 'PR Review Comments', got '%s'", state.Title())
+	}
+}
+
+func TestReviewCommentsState_PreferredWidth(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	width := state.PreferredWidth()
+
+	if width != ModalWidthWide {
+		t.Errorf("expected preferred width %d, got %d", ModalWidthWide, width)
+	}
+
+	if width <= ModalWidth {
+		t.Errorf("expected wide modal width (%d) to be greater than default modal width (%d)", width, ModalWidth)
+	}
+}
+
+func TestReviewCommentsState_ImplementsModalWithPreferredWidth(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	_, ok := interface{}(state).(ModalWithPreferredWidth)
+	if !ok {
+		t.Error("ReviewCommentsState should implement ModalWithPreferredWidth")
+	}
+}
+
+func TestReviewCommentsState_ImplementsModalWithSize(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	_, ok := interface{}(state).(ModalWithSize)
+	if !ok {
+		t.Error("ReviewCommentsState should implement ModalWithSize")
+	}
+}
+
+func TestReviewCommentsState_ImplementsModalState(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	var _ ModalState = state // Compile-time check
+}
+
+func TestReviewCommentsState_Help_Loading(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	help := state.Help()
+	if !strings.Contains(help, "Loading") {
+		t.Errorf("expected loading help text, got '%s'", help)
+	}
+}
+
+func TestReviewCommentsState_Help_Error(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetError("some error")
+	help := state.Help()
+	if !strings.Contains(help, "Esc") {
+		t.Errorf("expected error help to mention Esc, got '%s'", help)
+	}
+}
+
+func TestReviewCommentsState_Help_Normal(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{{Body: "test"}})
+	help := state.Help()
+	if !strings.Contains(help, "select all") {
+		t.Errorf("expected normal help to mention 'select all', got '%s'", help)
+	}
+	if !strings.Contains(help, "Enter") {
+		t.Errorf("expected normal help to mention 'Enter', got '%s'", help)
+	}
+}
+
+func TestReviewCommentsState_SetComments(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	comments := []ReviewCommentItem{
+		{Author: "user1", Body: "Fix this"},
+		{Author: "user2", Body: "And this"},
+	}
+	state.SetComments(comments)
+
+	if state.Loading {
+		t.Error("expected Loading to be false after SetComments")
+	}
+	if state.LoadError != "" {
+		t.Errorf("expected empty error after SetComments, got '%s'", state.LoadError)
+	}
+	if len(state.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(state.Comments))
+	}
+}
+
+func TestReviewCommentsState_SetError(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetError("gh pr view failed")
+
+	if state.Loading {
+		t.Error("expected Loading to be false after SetError")
+	}
+	if state.LoadError != "gh pr view failed" {
+		t.Errorf("expected error 'gh pr view failed', got '%s'", state.LoadError)
+	}
+}
+
+func TestReviewCommentsState_Update_Navigation(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Body: "first"},
+		{Body: "second"},
+		{Body: "third"},
+	})
+
+	// Move down
+	state.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if state.SelectedIndex != 1 {
+		t.Errorf("expected index 1 after down, got %d", state.SelectedIndex)
+	}
+
+	// Move down again
+	state.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if state.SelectedIndex != 2 {
+		t.Errorf("expected index 2 after second down, got %d", state.SelectedIndex)
+	}
+
+	// Move down at bottom - should stay
+	state.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if state.SelectedIndex != 2 {
+		t.Errorf("expected index 2 (clamped), got %d", state.SelectedIndex)
+	}
+
+	// Move up
+	state.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if state.SelectedIndex != 1 {
+		t.Errorf("expected index 1 after up, got %d", state.SelectedIndex)
+	}
+
+	// Move up to top
+	state.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if state.SelectedIndex != 0 {
+		t.Errorf("expected index 0 after up to top, got %d", state.SelectedIndex)
+	}
+
+	// Move up at top - should stay
+	state.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if state.SelectedIndex != 0 {
+		t.Errorf("expected index 0 (clamped), got %d", state.SelectedIndex)
+	}
+}
+
+func TestReviewCommentsState_Update_ToggleSelection(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Body: "first", Selected: false},
+		{Body: "second", Selected: false},
+	})
+
+	// Toggle first item
+	state.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if !state.Comments[0].Selected {
+		t.Error("expected first comment to be selected after space")
+	}
+
+	// Toggle again to deselect
+	state.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	if state.Comments[0].Selected {
+		t.Error("expected first comment to be deselected after second space")
+	}
+}
+
+func TestReviewCommentsState_Update_SelectAll(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Body: "first", Selected: false},
+		{Body: "second", Selected: false},
+		{Body: "third", Selected: true},
+	})
+
+	// Press 'a' - not all selected, so select all
+	state.Update(tea.KeyPressMsg{Code: 'a'})
+	for i, c := range state.Comments {
+		if !c.Selected {
+			t.Errorf("expected comment %d to be selected after 'a'", i)
+		}
+	}
+
+	// Press 'a' again - all selected, so deselect all
+	state.Update(tea.KeyPressMsg{Code: 'a'})
+	for i, c := range state.Comments {
+		if c.Selected {
+			t.Errorf("expected comment %d to be deselected after second 'a'", i)
+		}
+	}
+}
+
+func TestReviewCommentsState_GetSelectedComments(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Body: "first", Selected: true},
+		{Body: "second", Selected: false},
+		{Body: "third", Selected: true},
+	})
+
+	selected := state.GetSelectedComments()
+	if len(selected) != 2 {
+		t.Fatalf("expected 2 selected, got %d", len(selected))
+	}
+	if selected[0].Body != "first" {
+		t.Errorf("expected first selected body 'first', got '%s'", selected[0].Body)
+	}
+	if selected[1].Body != "third" {
+		t.Errorf("expected second selected body 'third', got '%s'", selected[1].Body)
+	}
+}
+
+func TestReviewCommentsState_GetSelectedComments_NoneSelected(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Body: "first", Selected: false},
+		{Body: "second", Selected: false},
+	})
+
+	selected := state.GetSelectedComments()
+	if len(selected) != 0 {
+		t.Errorf("expected 0 selected, got %d", len(selected))
+	}
+}
+
+func TestReviewCommentsState_Render_Loading(t *testing.T) {
+	state := NewReviewCommentsState("s1", "feature-branch")
+	rendered := state.Render()
+	if !strings.Contains(rendered, "Fetching review comments") {
+		t.Error("expected loading message in render")
+	}
+	if !strings.Contains(rendered, "feature-branch") {
+		t.Error("expected branch name in render")
+	}
+}
+
+func TestReviewCommentsState_Render_Error(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetError("no pull requests found")
+	rendered := state.Render()
+	if !strings.Contains(rendered, "no pull requests found") {
+		t.Error("expected error message in render")
+	}
+}
+
+func TestReviewCommentsState_Render_NoComments(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments(nil)
+	rendered := state.Render()
+	if !strings.Contains(rendered, "No review comments found") {
+		t.Error("expected 'No review comments found' in render")
+	}
+}
+
+func TestReviewCommentsState_Render_WithComments(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Author: "reviewer", Body: "Please fix this bug", Selected: true},
+		{Author: "someone", Body: "What about X?", Selected: false},
+	})
+	rendered := state.Render()
+	if !strings.Contains(rendered, "@reviewer") {
+		t.Error("expected @reviewer in render")
+	}
+	if !strings.Contains(rendered, "@someone") {
+		t.Error("expected @someone in render")
+	}
+	if !strings.Contains(rendered, "[x]") {
+		t.Error("expected [x] checkbox for selected comment")
+	}
+	if !strings.Contains(rendered, "[ ]") {
+		t.Error("expected [ ] checkbox for unselected comment")
+	}
+	if !strings.Contains(rendered, "2 of 2") || !strings.Contains(rendered, "1 of 2") {
+		// One is selected out of two
+		if !strings.Contains(rendered, "1 of 2") {
+			t.Error("expected '1 of 2 comment(s) selected' in render")
+		}
+	}
+}
+
+func TestReviewCommentsState_Render_InlineComment(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetComments([]ReviewCommentItem{
+		{Author: "reviewer", Body: "Use mutex", Path: "internal/app.go", Line: 42, Selected: true},
+	})
+	rendered := state.Render()
+	if !strings.Contains(rendered, "internal/app.go:42") {
+		t.Error("expected file path and line in render for inline comment")
+	}
+}
+
+func TestReviewCommentsState_SetSize(t *testing.T) {
+	state := NewReviewCommentsState("s1", "branch")
+	state.SetSize(100, 50)
+	if state.availableWidth != 100 {
+		t.Errorf("expected availableWidth 100, got %d", state.availableWidth)
+	}
+}
+

--- a/internal/ui/modals/state.go
+++ b/internal/ui/modals/state.go
@@ -69,6 +69,16 @@ type IssueItem struct {
 	Selected bool
 }
 
+// ReviewCommentItem represents a PR review comment for display in the modal.
+type ReviewCommentItem struct {
+	Author   string // GitHub username
+	Body     string // Comment text
+	Path     string // File path (empty for top-level/review body comments)
+	Line     int    // Line number (0 for top-level/review body comments)
+	URL      string // Permalink
+	Selected bool   // Whether selected for addressing
+}
+
 // HelpShortcut represents a single keyboard shortcut for display
 type HelpShortcut struct {
 	Key  string


### PR DESCRIPTION
## Summary
Adds the ability to import PR review comments directly into a session via `Ctrl+R`, allowing Claude to address code review feedback.

## Changes
- Add `Ctrl+R` keyboard shortcut to import PR review comments (requires sidebar focus + active session)
- Add `FetchPRReviewComments` to `GitService` that fetches top-level PR comments, review body comments, and inline code review comments via `gh pr view --json reviews,comments`
- Add `ReviewCommentsState` modal with comment selection UI (toggle individual comments with Space, select all with `a`, send with Enter)
- Format selected comments into a structured prompt sent to Claude with file paths, line numbers, and author attribution
- Add `ReviewCommentItem` type to modal state system
- Add `CtrlR` key constant

## Test plan
- Run `go test ./...` to verify all tests pass
- Unit tests added for:
  - `FetchPRReviewComments`: success, CLI error, invalid JSON, empty reviews, empty review body, review body only
  - `ReviewCommentsState` modal: creation, navigation, toggle selection, select all, get selected comments, rendering in loading/error/empty/populated states, inline comment display, size tracking
- Manual testing: on a session with an open PR, press `Ctrl+R` to verify comments load and can be sent to Claude