### PR TITLE
feat(sidebar): add new PR comments indicator via polling

### DIFF
--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -370,6 +370,7 @@ func (m *Model) handleConfirmDeleteModal(key string, msg tea.KeyPressMsg, state 
 			m.sidebar.SetPendingQuestion(sess.ID, false)
 			m.sidebar.SetIdleWithResponse(sess.ID, false)
 			m.sidebar.SetUncommittedChanges(sess.ID, false)
+			m.sidebar.SetHasNewComments(sess.ID, false)
 			activeSessionID := "<nil>"
 			if m.activeSession != nil {
 				activeSessionID = m.activeSession.ID
@@ -1108,6 +1109,7 @@ func (m *Model) executeBulkDelete(sessionIDs []string) (tea.Model, tea.Cmd) {
 		m.sidebar.SetPendingQuestion(id, false)
 		m.sidebar.SetIdleWithResponse(id, false)
 		m.sidebar.SetUncommittedChanges(id, false)
+		m.sidebar.SetHasNewComments(id, false)
 
 		// Clear active session if deleted
 		if m.activeSession != nil && m.activeSession.ID == id {

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -36,6 +36,7 @@ type Session struct {
 	BroadcastGroupID string    `json:"broadcast_group_id,omitempty"` // Links sessions created from the same broadcast
 	WorkspaceID      string    `json:"workspace_id,omitempty"`       // Workspace this session belongs to
 	Containerized    bool      `json:"containerized,omitempty"`      // Whether this session runs inside a container
+	PRCommentCount   int       `json:"pr_comment_count,omitempty"`   // Last-seen PR comment count (comments + reviews)
 }
 
 // GetIssueRef returns the IssueRef for this session, converting from legacy IssueNumber if needed.
@@ -263,6 +264,20 @@ func (c *Config) SetSessionBroadcastGroup(sessionID, groupID string) bool {
 	for i := range c.Sessions {
 		if c.Sessions[i].ID == sessionID {
 			c.Sessions[i].BroadcastGroupID = groupID
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateSessionPRCommentCount updates the last-seen PR comment count for a session.
+func (c *Config) UpdateSessionPRCommentCount(sessionID string, count int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i := range c.Sessions {
+		if c.Sessions[i].ID == sessionID {
+			c.Sessions[i].PRCommentCount = count
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
Adds a visual indicator in the sidebar when a session's PR has new review comments since the user last viewed them. The existing PR status poller now also tracks comment counts, and an asterisk (`*`) appears next to sessions with unread comments.

## Changes
- Add `PRCommentCount` field to `Session` struct to persist last-seen comment count
- Add `GetBatchPRStatesWithComments()` to `GitService` that fetches PR states along with comment+review counts in a single `gh pr list` call
- Update PR poller to use the new batch query and compare comment counts against the stored value
- Add `hasNewComments` state to `Sidebar` with priority sorting (between uncommitted changes and normal)
- Render a `*` indicator next to session names with new comments (colored blue when not selected)
- Clear the new comments indicator when the user views PR review comments (ctrl-r)
- Clear indicator state on session delete (single and bulk)
- Add `UpdateSessionPRCommentCount()` config method with thread-safe locking
- Include `hasNewComments` in sidebar attention hash for proper re-rendering

## Test plan
- Unit tests added for `GetBatchPRStatesWithComments` (success, no comments, CLI error, invalid JSON, missing branch, draft PRs)
- Unit tests for `UpdateSessionPRCommentCount` (basic and thread-safety)
- Unit tests for `checkPRStatuses` comment count propagation
- Unit tests for sidebar: `HasNewComments` get/set, priority ordering, attention-based sorting, hash changes, and render indicator
- Run `go test ./...` to verify all tests pass