### PR TITLE
fix: resolve goroutine leaks, nil panics, and missing error handling

### DIFF
--- a/internal/ui/chat_render.go
+++ b/internal/ui/chat_render.go
@@ -134,7 +134,11 @@ func renderInlineMarkdown(line string) string {
 
 	// Extract and replace inline code with placeholders
 	line = inlineCodePattern.ReplaceAllStringFunc(line, func(match string) string {
-		code := inlineCodePattern.FindStringSubmatch(match)[1]
+		submatch := inlineCodePattern.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		code := submatch[1]
 		placeholder := fmt.Sprintf("\x00CODE%d\x00", codeIdx)
 		codeSpans = append(codeSpans, codeSpan{
 			placeholder: placeholder,
@@ -147,14 +151,20 @@ func renderInlineMarkdown(line string) string {
 
 	// Process bold (**text**)
 	line = boldPattern.ReplaceAllStringFunc(line, func(match string) string {
-		text := boldPattern.FindStringSubmatch(match)[1]
-		return MarkdownBoldStyle.Render(text)
+		submatch := boldPattern.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
+		return MarkdownBoldStyle.Render(submatch[1])
 	})
 
 	// Process italic with underscores (_text_)
 	// Only match underscores at word boundaries (not in identifiers like foo_bar_baz)
 	line = underscoreItalic.ReplaceAllStringFunc(line, func(match string) string {
 		submatch := underscoreItalic.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return match
+		}
 		text := submatch[1]
 		// Preserve any prefix/suffix boundary characters that were matched
 		prefix := ""
@@ -177,6 +187,9 @@ func renderInlineMarkdown(line string) string {
 	// Process links [text](url)
 	line = linkPattern.ReplaceAllStringFunc(line, func(match string) string {
 		parts := linkPattern.FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
 		text := parts[1]
 		url := parts[2]
 		return MarkdownLinkStyle.Render(text) + " (" + MarkdownLinkStyle.Render(url) + ")"

--- a/internal/ui/chat_test.go
+++ b/internal/ui/chat_test.go
@@ -550,6 +550,37 @@ func TestRenderInlineMarkdown(t *testing.T) {
 	}
 }
 
+func TestRenderInlineMarkdown_NoPanicOnEdgeCases(t *testing.T) {
+	// Regression tests: renderInlineMarkdown must not panic on edge-case inputs.
+	// These exercise the bounds checks added to FindStringSubmatch results.
+	edgeCases := []string{
+		"",
+		"`",
+		"``",
+		"**",
+		"****",
+		"_",
+		"__",
+		"[",
+		"]()",
+		"[text](",
+		"[text]()",
+		"[]",
+		"[](url)",
+		"plain text with no formatting",
+		"`single tick without close",
+		"**bold without close",
+		"_italic without close",
+		"[link without close",
+	}
+	for _, input := range edgeCases {
+		t.Run(input, func(t *testing.T) {
+			// Should not panic
+			_ = renderInlineMarkdown(input)
+		})
+	}
+}
+
 func TestRenderMarkdown(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
Fixes several reliability issues: goroutine leaks in MCP server channel forwarding, potential nil panics in markdown rendering, and a silently ignored error in container setup.

## Changes
- Buffer MCP response channels (size 1) so forwarding goroutines don't block when the server exits mid-request
- Add `sync.WaitGroup` to ensure forwarding goroutines finish before closing response channels
- Add bounds checks on `FindStringSubmatch` results in `renderInlineMarkdown` to prevent nil index panics
- Make `buildContainerRunArgs` return an error instead of silently ignoring `os.UserHomeDir` failures
- Add a 2-minute timeout context for parallel broadcast session creation to prevent indefinite hangs
- Add regression tests for all fixes

## Test plan
- `go test ./...` passes
- `TestBufferedResponseChannelUnblocksGoroutine` verifies goroutines exit when request channels close
- `TestRenderInlineMarkdown_NoPanicOnEdgeCases` verifies no panics on malformed markdown
- `TestBuildContainerRunArgs_ErrorsOnMissingHome` verifies error propagation when home dir is unavailable