### PR TITLE
feat(docs): add animated dot grid background to landing page hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,6 +68,37 @@
         .hero {
             text-align: center;
             padding: 3rem 0 2rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .hero::before {
+            content: '';
+            position: absolute;
+            inset: -50% -50%;
+            width: 200%;
+            height: 200%;
+            background-image: radial-gradient(
+                circle,
+                rgba(124, 58, 237, 0.15) 1px,
+                transparent 1px
+            );
+            background-size: 28px 28px;
+            animation: heroGridDrift 25s linear infinite;
+            pointer-events: none;
+            z-index: 0;
+            mask-image: radial-gradient(ellipse at center, black 20%, transparent 70%);
+            -webkit-mask-image: radial-gradient(ellipse at center, black 20%, transparent 70%);
+        }
+
+        .hero > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        @keyframes heroGridDrift {
+            0% { transform: translate(0, 0); }
+            100% { transform: translate(28px, 28px); }
         }
 
         .logo-svg {


### PR DESCRIPTION
## Summary
Adds a subtle animated dot grid background effect to the hero section of the landing page for visual polish.

## Changes
- Add CSS pseudo-element (`::before`) on `.hero` with a radial-gradient dot pattern
- Animate the grid with a slow drifting motion (`heroGridDrift` keyframe, 25s loop)
- Apply radial mask to fade dots toward edges for a vignette effect
- Ensure hero content stays above the background via `z-index` layering

## Test plan
- Open `docs/index.html` in a browser and verify the dot grid animates smoothly behind the hero content
- Confirm text and other hero elements remain readable and clickable
- Check cross-browser rendering (Safari `-webkit-mask-image`, Chrome, Firefox)