### PR TITLE
feat(mcp): add get_review_comments tool for automated supervisors

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -244,6 +244,12 @@ type PushBranchRequestMsg struct {
 	Request   mcp.PushBranchRequest
 }
 
+// GetReviewCommentsRequestMsg is sent when the automated supervisor's MCP tool get_review_comments is called
+type GetReviewCommentsRequestMsg struct {
+	SessionID string
+	Request   mcp.GetReviewCommentsRequest
+}
+
 // ContainerImageUpdateMsg is sent when the background container image update check completes
 type ContainerImageUpdateMsg struct {
 	NeedsUpdate bool
@@ -797,6 +803,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case PushBranchRequestMsg:
 		return m.handlePushBranchRequestMsg(msg)
+
+	case GetReviewCommentsRequestMsg:
+		return m.handleGetReviewCommentsRequestMsg(msg)
 
 	case ContainerImageUpdateMsg:
 		if msg.NeedsUpdate {

--- a/internal/app/listeners.go
+++ b/internal/app/listeners.go
@@ -43,6 +43,7 @@ func (m *Model) sessionListeners(sessionID string, runner claude.RunnerInterface
 		cmds = append(cmds,
 			m.listenForCreatePRRequest(sessionID, runner),
 			m.listenForPushBranchRequest(sessionID, runner),
+			m.listenForGetReviewCommentsRequest(sessionID, runner),
 		)
 	}
 
@@ -196,6 +197,21 @@ func (m *Model) listenForPushBranchRequest(sessionID string, runner claude.Runne
 			return nil
 		}
 		return PushBranchRequestMsg{SessionID: sessionID, Request: req}
+	}
+}
+
+// listenForGetReviewCommentsRequest creates a command to listen for get review comments requests from an automated supervisor
+func (m *Model) listenForGetReviewCommentsRequest(sessionID string, runner claude.RunnerInterface) tea.Cmd {
+	ch := runner.GetReviewCommentsRequestChan()
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		req, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return GetReviewCommentsRequestMsg{SessionID: sessionID, Request: req}
 	}
 }
 

--- a/internal/claude/mcp_config.go
+++ b/internal/claude/mcp_config.go
@@ -57,6 +57,7 @@ func (r *Runner) ensureServerRunning() error {
 		socketOpts = append(socketOpts, mcp.WithHostToolChannels(
 			r.mcp.CreatePRReq, r.mcp.CreatePRResp,
 			r.mcp.PushBranchReq, r.mcp.PushBranchResp,
+			r.mcp.GetReviewCommentsReq, r.mcp.GetReviewCommentsResp,
 		))
 	}
 

--- a/internal/claude/runner_interface.go
+++ b/internal/claude/runner_interface.go
@@ -52,6 +52,8 @@ type RunnerInterface interface {
 	SendCreatePRResponse(resp mcp.CreatePRResponse)
 	PushBranchRequestChan() <-chan mcp.PushBranchRequest
 	SendPushBranchResponse(resp mcp.PushBranchResponse)
+	GetReviewCommentsRequestChan() <-chan mcp.GetReviewCommentsRequest
+	SendGetReviewCommentsResponse(resp mcp.GetReviewCommentsResponse)
 
 	// Lifecycle
 	Stop()

--- a/internal/claude/runner_state.go
+++ b/internal/claude/runner_state.go
@@ -30,10 +30,12 @@ type MCPChannels struct {
 	MergeChildResp   chan mcp.MergeChildResponse
 
 	// Host tool channels (nil when not an autonomous supervisor session)
-	CreatePRReq    chan mcp.CreatePRRequest
-	CreatePRResp   chan mcp.CreatePRResponse
-	PushBranchReq  chan mcp.PushBranchRequest
-	PushBranchResp chan mcp.PushBranchResponse
+	CreatePRReq           chan mcp.CreatePRRequest
+	CreatePRResp          chan mcp.CreatePRResponse
+	PushBranchReq         chan mcp.PushBranchRequest
+	PushBranchResp        chan mcp.PushBranchResponse
+	GetReviewCommentsReq  chan mcp.GetReviewCommentsRequest
+	GetReviewCommentsResp chan mcp.GetReviewCommentsResponse
 }
 
 // NewMCPChannels creates a new MCPChannels with buffered channels.
@@ -66,6 +68,8 @@ func (m *MCPChannels) InitHostToolChannels() {
 	m.CreatePRResp = make(chan mcp.CreatePRResponse, PermissionChannelBuffer)
 	m.PushBranchReq = make(chan mcp.PushBranchRequest, PermissionChannelBuffer)
 	m.PushBranchResp = make(chan mcp.PushBranchResponse, PermissionChannelBuffer)
+	m.GetReviewCommentsReq = make(chan mcp.GetReviewCommentsRequest, PermissionChannelBuffer)
+	m.GetReviewCommentsResp = make(chan mcp.GetReviewCommentsResponse, PermissionChannelBuffer)
 }
 
 // Close closes all channels. Safe to call multiple times.
@@ -133,6 +137,14 @@ func (m *MCPChannels) Close() {
 	if m.PushBranchResp != nil {
 		close(m.PushBranchResp)
 		m.PushBranchResp = nil
+	}
+	if m.GetReviewCommentsReq != nil {
+		close(m.GetReviewCommentsReq)
+		m.GetReviewCommentsReq = nil
+	}
+	if m.GetReviewCommentsResp != nil {
+		close(m.GetReviewCommentsResp)
+		m.GetReviewCommentsResp = nil
 	}
 }
 

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -251,3 +251,25 @@ type PushBranchResponse struct {
 	Success bool        `json:"success"`         // Whether push was successful
 	Error   string      `json:"error,omitempty"` // Error message if push failed
 }
+
+// GetReviewCommentsRequest represents a request from an automated supervisor to get PR review comments
+type GetReviewCommentsRequest struct {
+	ID interface{} `json:"id"` // JSON-RPC request ID for response correlation
+}
+
+// ReviewComment represents a single review comment for JSON serialization
+type ReviewComment struct {
+	Author string `json:"author"`          // GitHub username
+	Body   string `json:"body"`            // Comment text
+	Path   string `json:"path,omitempty"`  // File path (empty for top-level comments)
+	Line   int    `json:"line,omitempty"`  // Line number (0 for top-level comments)
+	URL    string `json:"url,omitempty"`   // Permalink
+}
+
+// GetReviewCommentsResponse represents the result of fetching PR review comments
+type GetReviewCommentsResponse struct {
+	ID       interface{}     `json:"id"`                // Correlates with request ID
+	Success  bool            `json:"success"`           // Whether fetch was successful
+	Comments []ReviewComment `json:"comments,omitempty"` // List of review comments
+	Error    string          `json:"error,omitempty"`   // Error message if fetch failed
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1104,10 +1104,12 @@ func TestServer_handleToolsList_supervisor(t *testing.T) {
 		createPRResp := make(chan CreatePRResponse, 1)
 		pushBranchChan := make(chan PushBranchRequest, 1)
 		pushBranchResp := make(chan PushBranchResponse, 1)
+		getReviewCommentsChan := make(chan GetReviewCommentsRequest, 1)
+		getReviewCommentsResp := make(chan GetReviewCommentsResponse, 1)
 
 		s := NewServer(strings.NewReader(""), &buf, nil, nil, nil, nil, nil, nil, nil, "test",
 			WithSupervisor(createChildChan, createChildResp, listChildrenChan, listChildrenResp, mergeChildChan, mergeChildResp),
-			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp))
+			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp, getReviewCommentsChan, getReviewCommentsResp))
 
 		if !s.isSupervisor {
 			t.Error("server should be supervisor")
@@ -1352,9 +1354,11 @@ func TestServer_handleCreatePR(t *testing.T) {
 		createPRResp := make(chan CreatePRResponse, 1)
 		pushBranchChan := make(chan PushBranchRequest, 1)
 		pushBranchResp := make(chan PushBranchResponse, 1)
+		getReviewCommentsChan := make(chan GetReviewCommentsRequest, 1)
+		getReviewCommentsResp := make(chan GetReviewCommentsResponse, 1)
 
 		s := NewServer(strings.NewReader(""), &buf, nil, nil, nil, nil, nil, nil, nil, "test",
-			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp))
+			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp, getReviewCommentsChan, getReviewCommentsResp))
 
 		go func() {
 			req := <-createPRChan
@@ -1405,9 +1409,11 @@ func TestServer_handlePushBranch(t *testing.T) {
 		createPRResp := make(chan CreatePRResponse, 1)
 		pushBranchChan := make(chan PushBranchRequest, 1)
 		pushBranchResp := make(chan PushBranchResponse, 1)
+		getReviewCommentsChan := make(chan GetReviewCommentsRequest, 1)
+		getReviewCommentsResp := make(chan GetReviewCommentsResponse, 1)
 
 		s := NewServer(strings.NewReader(""), &buf, nil, nil, nil, nil, nil, nil, nil, "test",
-			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp))
+			WithHostTools(createPRChan, createPRResp, pushBranchChan, pushBranchResp, getReviewCommentsChan, getReviewCommentsResp))
 
 		go func() {
 			req := <-pushBranchChan


### PR DESCRIPTION
## Summary
Adds a new MCP tool `get_review_comments` that allows automated supervisor sessions to fetch all review comments from the current branch's pull request. This enables AI supervisors to read and respond to PR feedback programmatically.

## Changes
- Added `get_review_comments` MCP tool that returns all PR review comments (top-level, review body, and inline code comments)
- Implemented request/response channels and handlers throughout the MCP stack (server, socket client/server, runner interface)
- Added `GetReviewCommentsRequestMsg` handler in Bubble Tea app layer that calls `GitService.FetchPRReviewComments`
- Extended MockRunner with get_review_comments channel support for testing
- Updated Docker workflow to expose the new tool in containerized sessions

## Test plan
- Unit tests pass (`go test ./...`)
- Manual test: Create an automated supervisor session, ensure it can call `get_review_comments` tool
- Verify tool is available in `tools/list` response when `--mcp-host-tools` is enabled
- Verify tool correctly fetches and returns PR comments in JSON format
- Test error handling when no PR exists or fetch fails

Fixes #237