### PR TITLE
fix(ui): prevent container progress bar showing on every message send

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1200,7 +1200,8 @@ func (m *Model) selectSession(sess *config.Session) {
 	}
 
 	// Restore container initialization state
-	if result.ContainerInitializing {
+	// Only show container init progress if session hasn't started yet
+	if result.ContainerInitializing && !sess.Started {
 		m.chat.SetContainerInitializing(true, result.ContainerInitStart)
 	} else {
 		m.chat.SetContainerInitializing(false, time.Time{})

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/zhubert/plural/internal/config"
 	"github.com/zhubert/plural/internal/ui"
@@ -63,5 +64,112 @@ func TestNew_ThemeStylesMatchThemeColors(t *testing.T) {
 					tt.themeName, expectedTheme.Name, currentTheme.Name)
 			}
 		})
+	}
+}
+
+func TestSelectSession_ContainerInitProgressBar_DoesNotShowAfterStarted(t *testing.T) {
+	// This tests the fix for GitHub issue #232
+	// The container progress bar should NOT show when sending messages to an already-started container
+
+	cfg := testConfig()
+	cfg.Sessions = []config.Session{
+		{
+			ID:            "container-session",
+			RepoPath:      "/test",
+			WorkTree:      "/test/.plural-worktrees/abc",
+			Branch:        "test-branch",
+			Name:          "Container Session",
+			Containerized: true,
+			Started:       true, // Session already started
+		},
+	}
+
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Simulate the session state manager having stale ContainerInitializing state
+	// (this could happen due to a race condition or timing issue)
+	m.sessionState().StartContainerInit("container-session")
+
+	// Verify the state manager thinks it's initializing
+	_, initializing := m.sessionState().GetContainerInitStart("container-session")
+	if !initializing {
+		t.Fatal("Expected session state to be initializing for this test")
+	}
+
+	// Now select the session
+	sess := &cfg.Sessions[0]
+	m.selectSession(sess)
+
+	// CRITICAL: Even though SessionStateManager has ContainerInitializing=true,
+	// the progress bar should NOT be shown because sess.Started=true
+	if m.chat.IsContainerInitializing() {
+		t.Error("Container progress bar should NOT show for already-started session, even if SessionStateManager has stale state")
+	}
+}
+
+func TestSelectSession_ContainerInitProgressBar_ShowsWhenNotStarted(t *testing.T) {
+	// Verify the progress bar DOES show when the session hasn't started yet
+
+	cfg := testConfig()
+	cfg.Sessions = []config.Session{
+		{
+			ID:            "new-container-session",
+			RepoPath:      "/test",
+			WorkTree:      "/test/.plural-worktrees/xyz",
+			Branch:        "test-branch",
+			Name:          "New Container Session",
+			Containerized: true,
+			Started:       false, // Session NOT started yet
+		},
+	}
+
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Mark as initializing
+	m.sessionState().StartContainerInit("new-container-session")
+
+	// Select the session
+	sess := &cfg.Sessions[0]
+	m.selectSession(sess)
+
+	// Progress bar SHOULD show because session hasn't started yet
+	if !m.chat.IsContainerInitializing() {
+		t.Error("Container progress bar SHOULD show for not-yet-started containerized session")
+	}
+}
+
+func TestSelectSession_ContainerInitProgressBar_ClearsWhenNotInitializing(t *testing.T) {
+	// Verify the progress bar is cleared when not initializing
+
+	cfg := testConfig()
+	cfg.Sessions = []config.Session{
+		{
+			ID:            "container-session",
+			RepoPath:      "/test",
+			WorkTree:      "/test/.plural-worktrees/def",
+			Branch:        "test-branch",
+			Name:          "Container Session",
+			Containerized: true,
+			Started:       false,
+		},
+	}
+
+	m := testModelWithSize(cfg, 120, 40)
+
+	// Manually set container initializing state in chat
+	m.chat.SetContainerInitializing(true, time.Now())
+
+	// Verify it's set
+	if !m.chat.IsContainerInitializing() {
+		t.Fatal("Expected container initializing to be set")
+	}
+
+	// Select the session (but DON'T mark as initializing in state manager)
+	sess := &cfg.Sessions[0]
+	m.selectSession(sess)
+
+	// Progress bar should be cleared
+	if m.chat.IsContainerInitializing() {
+		t.Error("Container progress bar should be cleared when not initializing in state manager")
 	}
 }


### PR DESCRIPTION
## Summary
Fixes a bug where the container initialization progress bar would incorrectly appear every time a message was sent to an already-started containerized session.

## Changes
- Add check for `sess.Started` flag when restoring container initialization state
- Only show container progress bar if session hasn't started yet (`!sess.Started`)
- Add comprehensive test coverage for container progress bar display logic:
  - Test that progress bar does NOT show for already-started sessions
  - Test that progress bar DOES show for not-yet-started sessions
  - Test that progress bar is properly cleared when not initializing

## Test plan
- Run `go test ./internal/app/...` to verify new test cases pass
- Manual testing:
  1. Create a containerized session and wait for it to start
  2. Send a message to the session
  3. Verify the container initialization progress bar does NOT appear
  4. Create a new containerized session
  5. Verify the progress bar DOES appear during initial container setup

Fixes #232