### PR TITLE
fix: enable auto-merge for PRs created by autonomous supervisors

### DIFF
--- a/internal/app/automation_handlers.go
+++ b/internal/app/automation_handlers.go
@@ -1002,6 +1002,14 @@ func (m *Model) handlePRCreatedFromToolMsg(msg PRCreatedFromToolMsg) (tea.Model,
 	}
 	m.sidebar.SetSessions(m.getFilteredSessions())
 	log.Info("marked session as PR created via tool", "prURL", msg.PRURL)
+
+	// Start CI polling for auto-merge if enabled
+	sess := m.config.GetSession(msg.SessionID)
+	if sess != nil && sess.Autonomous && m.config.GetRepoAutoMerge(sess.RepoPath) {
+		log.Info("starting CI polling for auto-merge", "branch", sess.Branch)
+		return m, m.pollCIForAutoMerge(msg.SessionID)
+	}
+
 	return m, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes auto-merge functionality for PRs created by autonomous supervisor sessions via the `create_pr` MCP tool.

**Problem**: When autonomous supervisors create PRs using the `create_pr` MCP tool, CI polling for auto-merge was never started. This meant PRs would sit waiting for manual merge even when `repo_auto_merge` was enabled for the repository.

**Root cause**: The `handlePRCreatedFromToolMsg` handler was missing the CI polling trigger logic that exists in the regular PR creation flow.

## Changes

1. **Auto-merge fix** (`automation_handlers.go`):
   - Added CI polling trigger in `handlePRCreatedFromToolMsg` 
   - Now checks if session is autonomous and repo has auto-merge enabled
   - Starts CI polling to auto-merge when checks pass

2. **Debug logging** (`issue_poller.go`):
   - Added debug logs to help diagnose issue polling
   - Logs repo detection, polling config, and issue fetching

## Test plan

- [x] Verified issue polling detects issues with "automatic" label
- [x] Verified autonomous supervisor sessions are created
- [x] Verified PR creation via `create_pr` tool works
- [ ] Verify CI polling starts after PR creation (requires restart)
- [ ] Verify auto-merge executes when CI passes

## Related

This was discovered while debugging why issue #232's autonomous session created PR #240 but didn't auto-merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)