### PR TITLE
refactor(ui): reorder auto-merge field before issue label in repo settings

### DIFF
--- a/internal/ui/modals/config.go
+++ b/internal/ui/modals/config.go
@@ -449,12 +449,12 @@ func (s *RepoSettingsState) numFields() int {
 
 // Focus indices for repo settings fields
 func (s *RepoSettingsState) issuePollingFocusIndex() int { return 0 }
-func (s *RepoSettingsState) issueLabelFocusIndex() int   { return 1 }
-func (s *RepoSettingsState) autoMergeFocusIndex() int    { return 2 }
+func (s *RepoSettingsState) autoMergeFocusIndex() int    { return 1 }
+func (s *RepoSettingsState) issueLabelFocusIndex() int   { return 2 }
 
 func (s *RepoSettingsState) asanaFocusIndex() int {
 	if s.ContainersSupported {
-		return 3 // after issue polling, issue label, auto-merge
+		return 3 // after issue polling, auto-merge, issue label
 	}
 	return 0 // first field if no containers
 }

--- a/internal/ui/modals/config_test.go
+++ b/internal/ui/modals/config_test.go
@@ -674,11 +674,11 @@ func TestRepoSettingsState_FocusIndices_ContainersAndAsana(t *testing.T) {
 	if idx := s.issuePollingFocusIndex(); idx != 0 {
 		t.Errorf("Expected issuePolling focus index 0, got %d", idx)
 	}
-	if idx := s.issueLabelFocusIndex(); idx != 1 {
-		t.Errorf("Expected issueLabel focus index 1, got %d", idx)
+	if idx := s.autoMergeFocusIndex(); idx != 1 {
+		t.Errorf("Expected autoMerge focus index 1, got %d", idx)
 	}
-	if idx := s.autoMergeFocusIndex(); idx != 2 {
-		t.Errorf("Expected autoMerge focus index 2, got %d", idx)
+	if idx := s.issueLabelFocusIndex(); idx != 2 {
+		t.Errorf("Expected issueLabel focus index 2, got %d", idx)
 	}
 	if idx := s.asanaFocusIndex(); idx != 3 {
 		t.Errorf("Expected asana focus index 3, got %d", idx)


### PR DESCRIPTION
## Summary
Reorders the "Auto-merge after CI" checkbox to appear before the "Issue filter label" input field in the repository settings modal.

## Changes
- Moved auto-merge checkbox from index 2 to index 1
- Moved issue label input from index 1 to index 2
- Updated focus index methods to reflect new order
- Updated corresponding test assertions
- Field order is now: Issue polling → Auto-merge after CI → Issue filter label

## Test plan
- Open repository settings modal (with containers supported)
- Verify fields appear in the new order (auto-merge before issue label)
- Tab through fields to confirm focus order matches visual order
- Run `go test ./internal/ui/modals/...` to verify all tests pass

Fixes #234