### PR TITLE
Fix multi-select "s" key off-by-one bug in sidebar (#242)

### DIFF
--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -585,10 +585,9 @@ func (s *Sidebar) sortNodesByPriority(nodes []sessionNode) {
 func (s *Sidebar) EnterMultiSelect() {
 	s.multiSelectMode = true
 	s.selectedSessions = make(map[string]bool)
-	// Pre-select the currently highlighted session
-	sessions := s.visibleSessions()
-	if s.selectedIdx >= 0 && s.selectedIdx < len(sessions) {
-		s.selectedSessions[sessions[s.selectedIdx].ID] = true
+	// Pre-select the currently highlighted session (if it's a session, not a repo header or new session item)
+	if sess := s.SelectedSession(); sess != nil {
+		s.selectedSessions[sess.ID] = true
 	}
 }
 
@@ -614,15 +613,15 @@ func (s *Sidebar) GetSelectedSessionIDs() []string {
 
 // ToggleSelected toggles the selection of the currently highlighted session
 func (s *Sidebar) ToggleSelected() {
-	sessions := s.visibleSessions()
-	if s.selectedIdx < 0 || s.selectedIdx >= len(sessions) {
+	// Only toggle if a session is currently selected (not a repo header or new session item)
+	sess := s.SelectedSession()
+	if sess == nil {
 		return
 	}
-	id := sessions[s.selectedIdx].ID
-	if s.selectedSessions[id] {
-		delete(s.selectedSessions, id)
+	if s.selectedSessions[sess.ID] {
+		delete(s.selectedSessions, sess.ID)
 	} else {
-		s.selectedSessions[id] = true
+		s.selectedSessions[sess.ID] = true
 	}
 }
 


### PR DESCRIPTION
PROBLEM:
The "s" key multi-select feature had an off-by-one error where selecting an item would actually select the item below it instead. This was because the selection logic didn't account for non-session items (repo headers and "+ New Session" items) in the sidebar's items list.

SOLUTION:
- Updated EnterMultiSelect() to use SelectedSession() instead of directly indexing into visibleSessions() with selectedIdx
- Updated ToggleSelected() to use SelectedSession() which correctly maps the cursor position to the actual session, handling non-session items
- SelectedSession() already handles the mapping from items list (which includes repo headers and new session items) to actual sessions

TESTS ADDED:
- TestSidebar_MultiSelect_CorrectSessionSelected: Verifies the focused item is correctly selected, not the one below
- TestSidebar_MultiSelect_NonSessionItemsNotSelectable: Ensures repo headers and "+ New Session" items cannot be selected
- TestSidebar_MultiSelect_FirstLastSession: Tests boundary conditions

All existing multi-select tests continue to pass.