### PR TITLE
feat: detect user's terminal for ctrl-e instead of hardcoding Terminal.app

### DIFF
--- a/internal/app/shortcuts_test.go
+++ b/internal/app/shortcuts_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"os"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -1180,9 +1179,7 @@ func TestDetectTerminalApp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := os.Getenv("TERM_PROGRAM")
-			os.Setenv("TERM_PROGRAM", tt.envValue)
-			defer os.Setenv("TERM_PROGRAM", original)
+			t.Setenv("TERM_PROGRAM", tt.envValue)
 
 			result := detectTerminalApp()
 			if result != tt.expected {


### PR DESCRIPTION
## Summary
Automatically detects the user's terminal emulator via `TERM_PROGRAM` environment variable and opens new terminal windows using the correct application, instead of always assuming macOS Terminal.app.

## Changes
- Add `detectTerminalApp()` function that maps `TERM_PROGRAM` values to terminal app names (Ghostty, iTerm2, kitty, WezTerm, Alacritty, Terminal.app)
- Update `openTerminalInContainer()` on macOS to use native CLI for kitty and WezTerm, and AppleScript with the correct app name for others
- Update `openTerminalAtPath()` on macOS with the same terminal-aware logic
- On Linux, prepend the detected terminal to the fallback list so it's tried first
- Add table-driven tests for `detectTerminalApp()` covering all supported terminals, case insensitivity, and fallback behavior

## Test plan
- Run `go test ./internal/app/...` to verify the new `TestDetectTerminalApp` tests pass
- Set `TERM_PROGRAM` to various values (ghostty, iTerm.app, kitty, wezterm, alacritty) and use ctrl-e to open a terminal — verify the correct terminal opens
- Test with an unrecognized `TERM_PROGRAM` value to confirm fallback to Terminal.app
- Test container sessions (ctrl-e on a containerized session) to verify docker exec opens in the correct terminal

Fixes #231