### PR TITLE
feat(issues): add Linear integration as an issue provider

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -271,7 +271,8 @@ func New(cfg *config.Config, version string) *Model {
 	// Initialize issue providers
 	githubProvider := issues.NewGitHubProvider(gitSvc)
 	asanaProvider := issues.NewAsanaProvider(cfg)
-	issueRegistry := issues.NewProviderRegistry(githubProvider, asanaProvider)
+	linearProvider := issues.NewLinearProvider(cfg)
+	issueRegistry := issues.NewProviderRegistry(githubProvider, asanaProvider, linearProvider)
 
 	m := &Model{
 		config:         cfg,

--- a/internal/issues/linear.go
+++ b/internal/issues/linear.go
@@ -1,0 +1,260 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/zhubert/plural/internal/config"
+)
+
+const (
+	linearAPIBase       = "https://api.linear.app"
+	linearAPIKeyEnvVar  = "LINEAR_API_KEY"
+	linearHTTPTimeout   = 30 * time.Second
+)
+
+// LinearTeam represents a Linear team with its ID and name.
+type LinearTeam struct {
+	ID   string
+	Name string
+}
+
+// LinearProvider implements Provider for Linear Issues using the Linear GraphQL API.
+type LinearProvider struct {
+	config     *config.Config
+	httpClient *http.Client
+	apiBase    string // Override for testing; defaults to linearAPIBase
+}
+
+// NewLinearProvider creates a new Linear issue provider.
+func NewLinearProvider(cfg *config.Config) *LinearProvider {
+	return &LinearProvider{
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: linearHTTPTimeout,
+		},
+		apiBase: linearAPIBase,
+	}
+}
+
+// NewLinearProviderWithClient creates a new Linear issue provider with a custom HTTP client and API base URL (for testing).
+func NewLinearProviderWithClient(cfg *config.Config, client *http.Client, apiBase string) *LinearProvider {
+	if apiBase == "" {
+		apiBase = linearAPIBase
+	}
+	return &LinearProvider{
+		config:     cfg,
+		httpClient: client,
+		apiBase:    apiBase,
+	}
+}
+
+// Name returns the human-readable name of this provider.
+func (p *LinearProvider) Name() string {
+	return "Linear Issues"
+}
+
+// Source returns the source type for this provider.
+func (p *LinearProvider) Source() Source {
+	return SourceLinear
+}
+
+// linearGraphQLRequest represents a GraphQL request body.
+type linearGraphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+// linearIssue represents an issue from the Linear GraphQL API response.
+type linearIssue struct {
+	ID          string `json:"id"`
+	Identifier  string `json:"identifier"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+// linearTeamIssuesResponse represents the Linear GraphQL response for team issues.
+type linearTeamIssuesResponse struct {
+	Data struct {
+		Team struct {
+			Issues struct {
+				Nodes []linearIssue `json:"nodes"`
+			} `json:"issues"`
+		} `json:"team"`
+	} `json:"data"`
+}
+
+// linearTeam represents a team from the Linear GraphQL API response.
+type linearTeam struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// linearTeamsResponse represents the Linear GraphQL response for listing teams.
+type linearTeamsResponse struct {
+	Data struct {
+		Teams struct {
+			Nodes []linearTeam `json:"nodes"`
+		} `json:"teams"`
+	} `json:"data"`
+}
+
+// FetchIssues retrieves active issues from the Linear team.
+// The projectID should be the Linear team ID.
+func (p *LinearProvider) FetchIssues(ctx context.Context, repoPath, projectID string) ([]Issue, error) {
+	apiKey := os.Getenv(linearAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, fmt.Errorf("LINEAR_API_KEY environment variable not set")
+	}
+
+	if projectID == "" {
+		return nil, fmt.Errorf("Linear team ID not configured for this repository")
+	}
+
+	query := `query($teamId: String!) {
+  team(id: $teamId) {
+    issues(filter: { state: { type: { nin: ["completed", "canceled"] } } }) {
+      nodes {
+        id
+        identifier
+        title
+        description
+        url
+      }
+    }
+  }
+}`
+
+	gqlReq := linearGraphQLRequest{
+		Query: query,
+		Variables: map[string]interface{}{
+			"teamId": projectID,
+		},
+	}
+
+	body, err := json.Marshal(gqlReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GraphQL request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/graphql", p.apiBase)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("Linear API returned 403 Forbidden - check that your LINEAR_API_KEY has access to this team")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Linear API returned status %d", resp.StatusCode)
+	}
+
+	var gqlResp linearTeamIssuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gqlResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Linear response: %w", err)
+	}
+
+	nodes := gqlResp.Data.Team.Issues.Nodes
+	issues := make([]Issue, len(nodes))
+	for i, issue := range nodes {
+		issues[i] = Issue{
+			ID:     issue.Identifier,
+			Title:  issue.Title,
+			Body:   issue.Description,
+			URL:    issue.URL,
+			Source: SourceLinear,
+		}
+	}
+
+	return issues, nil
+}
+
+// IsConfigured returns true if Linear is configured for the given repo.
+// Requires both LINEAR_API_KEY env var and a team ID mapped to the repo.
+func (p *LinearProvider) IsConfigured(repoPath string) bool {
+	if os.Getenv(linearAPIKeyEnvVar) == "" {
+		return false
+	}
+	return p.config.HasLinearTeam(repoPath)
+}
+
+// GenerateBranchName returns a branch name for the given Linear issue.
+// Format: "linear-{identifier}" where identifier is lowercased (e.g., "linear-eng-123").
+func (p *LinearProvider) GenerateBranchName(issue Issue) string {
+	return fmt.Sprintf("linear-%s", strings.ToLower(issue.ID))
+}
+
+// GetPRLinkText returns the text to add to PR body to link/close the Linear issue.
+// Linear supports auto-close via identifier mentions (e.g., "Fixes ENG-123").
+func (p *LinearProvider) GetPRLinkText(issue Issue) string {
+	return fmt.Sprintf("Fixes %s", issue.ID)
+}
+
+// FetchTeams retrieves all teams accessible to the user.
+func (p *LinearProvider) FetchTeams(ctx context.Context) ([]LinearTeam, error) {
+	apiKey := os.Getenv(linearAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, fmt.Errorf("LINEAR_API_KEY environment variable not set")
+	}
+
+	gqlReq := linearGraphQLRequest{
+		Query: `{ teams { nodes { id name } } }`,
+	}
+
+	body, err := json.Marshal(gqlReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GraphQL request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/graphql", p.apiBase)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch teams: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Linear API returned status %d", resp.StatusCode)
+	}
+
+	var gqlResp linearTeamsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gqlResp); err != nil {
+		return nil, fmt.Errorf("failed to parse Linear teams response: %w", err)
+	}
+
+	nodes := gqlResp.Data.Teams.Nodes
+	teams := make([]LinearTeam, len(nodes))
+	for i, team := range nodes {
+		teams[i] = LinearTeam{
+			ID:   team.ID,
+			Name: team.Name,
+		}
+	}
+
+	return teams, nil
+}

--- a/internal/issues/linear_test.go
+++ b/internal/issues/linear_test.go
@@ -1,0 +1,355 @@
+package issues
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/zhubert/plural/internal/config"
+)
+
+func TestLinearProvider_Name(t *testing.T) {
+	p := NewLinearProvider(nil)
+	if p.Name() != "Linear Issues" {
+		t.Errorf("expected 'Linear Issues', got '%s'", p.Name())
+	}
+}
+
+func TestLinearProvider_Source(t *testing.T) {
+	p := NewLinearProvider(nil)
+	if p.Source() != SourceLinear {
+		t.Errorf("expected SourceLinear, got '%s'", p.Source())
+	}
+}
+
+func TestLinearProvider_IsConfigured(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SetLinearTeam("/test/repo", "team-123")
+
+	p := NewLinearProvider(cfg)
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+
+	// Test without API key
+	os.Setenv(linearAPIKeyEnvVar, "")
+	if p.IsConfigured("/test/repo") {
+		t.Error("expected IsConfigured=false without API key")
+	}
+
+	// Test with API key but without team mapping
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+	if p.IsConfigured("/other/repo") {
+		t.Error("expected IsConfigured=false without team mapping")
+	}
+
+	// Test with both API key and team mapping
+	if !p.IsConfigured("/test/repo") {
+		t.Error("expected IsConfigured=true with API key and team mapping")
+	}
+}
+
+func TestLinearProvider_GenerateBranchName(t *testing.T) {
+	p := NewLinearProvider(nil)
+
+	tests := []struct {
+		name     string
+		issue    Issue
+		expected string
+	}{
+		{"simple identifier", Issue{ID: "ENG-123"}, "linear-eng-123"},
+		{"uppercase identifier", Issue{ID: "PROJ-456"}, "linear-proj-456"},
+		{"already lowercase", Issue{ID: "eng-789"}, "linear-eng-789"},
+		{"mixed case", Issue{ID: "Dev-42"}, "linear-dev-42"},
+		{"long identifier", Issue{ID: "ENGINEERING-99999"}, "linear-engineering-99999"},
+		{"single char prefix", Issue{ID: "X-1"}, "linear-x-1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := p.GenerateBranchName(tc.issue)
+			if result != tc.expected {
+				t.Errorf("GenerateBranchName(%q) = %s, expected %s", tc.issue.ID, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLinearProvider_GetPRLinkText(t *testing.T) {
+	p := NewLinearProvider(nil)
+
+	tests := []struct {
+		name     string
+		issue    Issue
+		expected string
+	}{
+		{"standard identifier", Issue{ID: "ENG-123", Source: SourceLinear}, "Fixes ENG-123"},
+		{"different prefix", Issue{ID: "PROJ-456", Source: SourceLinear}, "Fixes PROJ-456"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := p.GetPRLinkText(tc.issue)
+			if result != tc.expected {
+				t.Errorf("GetPRLinkText(%q) = %s, expected %s", tc.issue.ID, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLinearProvider_FetchIssues_NoAPIKey(t *testing.T) {
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+
+	os.Setenv(linearAPIKeyEnvVar, "")
+
+	cfg := &config.Config{}
+	p := NewLinearProvider(cfg)
+
+	ctx := context.Background()
+	_, err := p.FetchIssues(ctx, "/test/repo", "team-123")
+	if err == nil {
+		t.Error("expected error without API key")
+	}
+}
+
+func TestLinearProvider_FetchIssues_NoTeamID(t *testing.T) {
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	cfg := &config.Config{}
+	p := NewLinearProvider(cfg)
+
+	ctx := context.Background()
+	_, err := p.FetchIssues(ctx, "/test/repo", "")
+	if err == nil {
+		t.Error("expected error without team ID")
+	}
+}
+
+func TestLinearProvider_FetchIssues_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header (Linear uses plain API key, not Bearer)
+		auth := r.Header.Get("Authorization")
+		if auth != "lin_api_test123" {
+			t.Errorf("expected 'lin_api_test123', got '%s'", auth)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Verify Content-Type
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type 'application/json', got '%s'", r.Header.Get("Content-Type"))
+		}
+
+		// Verify it's a POST to /graphql
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/graphql" {
+			t.Errorf("expected /graphql, got %s", r.URL.Path)
+		}
+
+		// Verify request body contains the team ID variable
+		body, _ := io.ReadAll(r.Body)
+		var gqlReq linearGraphQLRequest
+		json.Unmarshal(body, &gqlReq)
+		if gqlReq.Variables["teamId"] != "team-123" {
+			t.Errorf("expected teamId 'team-123', got '%v'", gqlReq.Variables["teamId"])
+		}
+
+		response := linearTeamIssuesResponse{}
+		response.Data.Team.Issues.Nodes = []linearIssue{
+			{ID: "uuid-1", Identifier: "ENG-123", Title: "Fix login bug", Description: "Login fails on mobile", URL: "https://linear.app/team/issue/ENG-123"},
+			{ID: "uuid-2", Identifier: "ENG-456", Title: "Add dark mode", Description: "Implement dark mode toggle", URL: "https://linear.app/team/issue/ENG-456"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	cfg := &config.Config{}
+	p := NewLinearProviderWithClient(cfg, server.Client(), server.URL)
+
+	ctx := context.Background()
+	issues, err := p.FetchIssues(ctx, "/test/repo", "team-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	// Verify identifier is used as ID
+	if issues[0].ID != "ENG-123" {
+		t.Errorf("expected ID 'ENG-123', got %q", issues[0].ID)
+	}
+	if issues[0].Title != "Fix login bug" {
+		t.Errorf("expected title 'Fix login bug', got %q", issues[0].Title)
+	}
+	if issues[0].Body != "Login fails on mobile" {
+		t.Errorf("expected body 'Login fails on mobile', got %q", issues[0].Body)
+	}
+	if issues[0].URL != "https://linear.app/team/issue/ENG-123" {
+		t.Errorf("expected URL 'https://linear.app/team/issue/ENG-123', got %q", issues[0].URL)
+	}
+	if issues[0].Source != SourceLinear {
+		t.Errorf("expected source SourceLinear, got %q", issues[0].Source)
+	}
+	if issues[1].ID != "ENG-456" {
+		t.Errorf("expected ID 'ENG-456', got %q", issues[1].ID)
+	}
+}
+
+func TestLinearProvider_FetchIssues_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	cfg := &config.Config{}
+	p := NewLinearProviderWithClient(cfg, server.Client(), server.URL)
+
+	ctx := context.Background()
+	_, err := p.FetchIssues(ctx, "/test/repo", "team-123")
+	if err == nil {
+		t.Error("expected error from API error response")
+	}
+}
+
+func TestLinearProvider_FetchIssues_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	cfg := &config.Config{}
+	p := NewLinearProviderWithClient(cfg, server.Client(), server.URL)
+
+	ctx := context.Background()
+	_, err := p.FetchIssues(ctx, "/test/repo", "team-123")
+	if err == nil {
+		t.Error("expected error from 403 response")
+	}
+	if err != nil && !contains(err.Error(), "403 Forbidden") {
+		t.Errorf("expected error to mention 403 Forbidden, got: %v", err)
+	}
+}
+
+func TestLinearProvider_FetchTeams_NoAPIKey(t *testing.T) {
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+
+	os.Setenv(linearAPIKeyEnvVar, "")
+
+	p := NewLinearProvider(nil)
+	ctx := context.Background()
+	_, err := p.FetchTeams(ctx)
+	if err == nil {
+		t.Error("expected error without API key")
+	}
+}
+
+func TestLinearProvider_FetchTeams_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		auth := r.Header.Get("Authorization")
+		if auth != "lin_api_test123" {
+			t.Errorf("expected 'lin_api_test123', got '%s'", auth)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Verify it's a POST to /graphql
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		response := linearTeamsResponse{}
+		response.Data.Teams.Nodes = []linearTeam{
+			{ID: "team-1", Name: "Engineering"},
+			{ID: "team-2", Name: "Design"},
+			{ID: "team-3", Name: "Product"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	p := NewLinearProviderWithClient(nil, server.Client(), server.URL)
+
+	ctx := context.Background()
+	teams, err := p.FetchTeams(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(teams) != 3 {
+		t.Fatalf("expected 3 teams, got %d", len(teams))
+	}
+	if teams[0].ID != "team-1" {
+		t.Errorf("expected ID 'team-1', got %q", teams[0].ID)
+	}
+	if teams[0].Name != "Engineering" {
+		t.Errorf("expected name 'Engineering', got %q", teams[0].Name)
+	}
+	if teams[1].Name != "Design" {
+		t.Errorf("expected name 'Design', got %q", teams[1].Name)
+	}
+	if teams[2].Name != "Product" {
+		t.Errorf("expected name 'Product', got %q", teams[2].Name)
+	}
+}
+
+func TestLinearProvider_FetchTeams_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origKey := os.Getenv(linearAPIKeyEnvVar)
+	defer os.Setenv(linearAPIKeyEnvVar, origKey)
+	os.Setenv(linearAPIKeyEnvVar, "lin_api_test123")
+
+	p := NewLinearProviderWithClient(nil, server.Client(), server.URL)
+
+	ctx := context.Background()
+	_, err := p.FetchTeams(ctx)
+	if err == nil {
+		t.Error("expected error from API error response")
+	}
+}
+
+// contains checks if a string contains a substring.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/issues/provider.go
+++ b/internal/issues/provider.go
@@ -6,12 +6,13 @@ import (
 	"context"
 )
 
-// Source identifies the origin of an issue (GitHub, Asana, etc.)
+// Source identifies the origin of an issue (GitHub, Asana, Linear, etc.)
 type Source string
 
 const (
 	SourceGitHub Source = "github"
 	SourceAsana  Source = "asana"
+	SourceLinear Source = "linear"
 )
 
 // Issue represents a generic issue/task from any supported source.
@@ -35,21 +36,25 @@ type Provider interface {
 	// The projectID parameter is provider-specific:
 	//   - GitHub: ignored (uses gh CLI with repoPath as working directory)
 	//   - Asana: the Asana project GID
+	//   - Linear: the Linear team ID
 	FetchIssues(ctx context.Context, repoPath, projectID string) ([]Issue, error)
 
 	// IsConfigured returns true if this provider is configured and usable for the given repo.
 	// For GitHub: always true (gh CLI is a prerequisite)
 	// For Asana: true if ASANA_PAT env var is set AND repo has a mapped project
+	// For Linear: true if LINEAR_API_KEY env var is set AND repo has a mapped team
 	IsConfigured(repoPath string) bool
 
 	// GenerateBranchName returns a branch name for the given issue.
 	// For GitHub: "issue-{number}"
 	// For Asana: "task-{slug}" where slug is derived from task name
+	// For Linear: "linear-{identifier}" where identifier is lowercased (e.g., "linear-eng-123")
 	GenerateBranchName(issue Issue) string
 
 	// GetPRLinkText returns the text to add to PR body to link/close the issue.
 	// For GitHub: "Fixes #123"
 	// For Asana: "" (Asana doesn't support auto-close via commit message)
+	// For Linear: "Fixes ENG-123" (Linear supports auto-close via identifier mentions)
 	GetPRLinkText(issue Issue) string
 }
 

--- a/internal/ui/modals/issues.go
+++ b/internal/ui/modals/issues.go
@@ -57,6 +57,8 @@ func (s *ImportIssuesState) Title() string {
 	switch s.Source {
 	case "asana":
 		return "Import Asana Tasks"
+	case "linear":
+		return "Import Linear Issues"
 	default:
 		return "Import GitHub Issues"
 	}
@@ -95,6 +97,9 @@ func (s *ImportIssuesState) Render() string {
 		if s.Source == "asana" {
 			loadingMsg = "Fetching tasks from Asana..."
 		}
+		if s.Source == "linear" {
+			loadingMsg = "Fetching issues from Linear..."
+		}
 		loadingText := lipgloss.NewStyle().
 			Foreground(ColorTextMuted).
 			Italic(true).
@@ -116,6 +121,9 @@ func (s *ImportIssuesState) Render() string {
 		if s.Source == "asana" {
 			noIssuesMsg = "No incomplete tasks found"
 		}
+		if s.Source == "linear" {
+			noIssuesMsg = "No active issues found"
+		}
 		noIssues := lipgloss.NewStyle().
 			Foreground(ColorTextMuted).
 			Italic(true).
@@ -127,6 +135,9 @@ func (s *ImportIssuesState) Render() string {
 	descMsg := "Select issues to import as sessions:"
 	if s.Source == "asana" {
 		descMsg = "Select tasks to import as sessions:"
+	}
+	if s.Source == "linear" {
+		descMsg = "Select issues to import as sessions:"
 	}
 	description := lipgloss.NewStyle().
 		Foreground(ColorTextMuted).
@@ -170,6 +181,9 @@ func (s *ImportIssuesState) Render() string {
 		var maxTitleLen int
 		if issue.Source == "asana" {
 			maxTitleLen = availableWidth - 8 // "  > [x] "
+		} else if issue.Source == "linear" {
+			// Account for identifier (e.g., "ENG-123: ")
+			maxTitleLen = availableWidth - 15
 		} else {
 			// Account for issue number (estimate ~7 chars for "#12345: ")
 			maxTitleLen = availableWidth - 15
@@ -181,10 +195,12 @@ func (s *ImportIssuesState) Render() string {
 			titleText = string(titleRunes[:maxTitleLen-3]) + "..."
 		}
 
-		// Format depends on source: GitHub uses "#123", Asana just shows title
+		// Format depends on source: GitHub uses "#123", Asana just shows title, Linear shows identifier
 		var issueLine string
 		if issue.Source == "asana" {
 			issueLine = fmt.Sprintf("%s %s", checkbox, titleText)
+		} else if issue.Source == "linear" {
+			issueLine = fmt.Sprintf("%s %s: %s", checkbox, issue.ID, titleText)
 		} else {
 			issueLine = fmt.Sprintf("%s #%s: %s", checkbox, issue.ID, titleText)
 		}

--- a/internal/ui/modals/state.go
+++ b/internal/ui/modals/state.go
@@ -59,13 +59,13 @@ type OptionItem struct {
 }
 
 // IssueItem represents an issue/task for display in the modal.
-// Works with both GitHub issues and Asana tasks.
+// Works with GitHub issues, Asana tasks, and Linear issues.
 type IssueItem struct {
-	ID       string // Issue/task ID ("123" for GitHub, "1234567890123" for Asana)
+	ID       string // Issue/task ID ("123" for GitHub, "1234567890123" for Asana, "ENG-123" for Linear)
 	Title    string
 	Body     string
 	URL      string
-	Source   string // "github" or "asana"
+	Source   string // "github", "asana", or "linear"
 	Selected bool
 }
 


### PR DESCRIPTION
## Summary
Adds Linear as a third issue provider alongside GitHub and Asana, allowing users to import Linear issues into Plural sessions via the Linear GraphQL API.

## Changes
- Add `LinearProvider` implementing the `Provider` interface with GraphQL API support for fetching issues and teams
- Add `SourceLinear` constant and register Linear in the provider registry
- Add per-repo Linear team ID configuration (`RepoLinearTeam` map) with `GetLinearTeam`/`SetLinearTeam`/`HasLinearTeam` methods
- Wire Linear into the issue source selection modal, import modal, and session creation flow
- Support Linear-specific branch naming (`linear-eng-123`), PR link text (`Fixes ENG-123`), and issue display formatting
- Add comprehensive tests for the Linear provider (API calls, error handling, branch naming, PR links)

## Test plan
- Run `go test ./internal/issues/...` to verify Linear provider tests pass
- Run `go test ./...` to verify no regressions across the codebase
- Manual testing: set `LINEAR_API_KEY` env var, configure a repo with a Linear team ID, and verify issues can be fetched and imported as sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #248