### PR TITLE
fix(exec): protect DefaultExecutor global with mutex for thread safety

### DIFF
--- a/internal/exec/executor.go
+++ b/internal/exec/executor.go
@@ -337,10 +337,22 @@ var _ CommandExecutor = (*MockExecutor)(nil)
 var _ CommandHandle = (*realCommandHandle)(nil)
 var _ CommandHandle = (*mockCommandHandle)(nil)
 
-// DefaultExecutor is the global default executor (can be swapped for testing).
-var DefaultExecutor CommandExecutor = NewRealExecutor()
+// defaultExecutorMu protects defaultExecutor for concurrent access.
+var defaultExecutorMu sync.RWMutex
+
+// defaultExecutor is the global default executor (can be swapped for testing).
+var defaultExecutor CommandExecutor = NewRealExecutor()
+
+// GetDefaultExecutor returns the global default executor.
+func GetDefaultExecutor() CommandExecutor {
+	defaultExecutorMu.RLock()
+	defer defaultExecutorMu.RUnlock()
+	return defaultExecutor
+}
 
 // SetDefaultExecutor sets the global default executor.
 func SetDefaultExecutor(e CommandExecutor) {
-	DefaultExecutor = e
+	defaultExecutorMu.Lock()
+	defer defaultExecutorMu.Unlock()
+	defaultExecutor = e
 }


### PR DESCRIPTION
## Summary
Fixes a data race on the global `DefaultExecutor` variable and removes a deprecated wrapper function that is no longer called.

## Changes
- Replace exported `DefaultExecutor` global variable with unexported `defaultExecutor` protected by `sync.RWMutex`
- Add `GetDefaultExecutor()` and update `SetDefaultExecutor()` to use proper locking
- Add concurrent access test (`TestDefaultExecutorConcurrentAccess`) to verify thread safety
- Remove deprecated `GeneratePRTitleAndBody` wrapper in favor of `GeneratePRTitleAndBodyWithIssueRef`

## Test plan
- `go test ./internal/exec/...` — verifies mutex-protected accessor/setter and concurrent access
- `go test ./internal/git/...` — verifies removal of deprecated wrapper has no impact
- `go test -race ./...` — confirms the data race is resolved

Fixes #256