### PR TITLE
refactor(mcp): consolidate channel duplication with generic ChannelPair

### DIFF
--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -385,7 +385,7 @@ func (r *Runner) PermissionRequestChan() <-chan mcp.PermissionRequest {
 	if r.stopped || r.mcp == nil {
 		return nil
 	}
-	return r.mcp.PermissionReq
+	return r.mcp.Permission.Req
 }
 
 // SendPermissionResponse sends a response to a permission request.
@@ -394,8 +394,8 @@ func (r *Runner) SendPermissionResponse(resp mcp.PermissionResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.PermissionResponse
-	if r.mcp != nil {
-		ch = r.mcp.PermissionResp
+	if r.mcp != nil && r.mcp.Permission != nil {
+		ch = r.mcp.Permission.Resp
 	}
 	r.mu.RUnlock()
 
@@ -419,7 +419,7 @@ func (r *Runner) QuestionRequestChan() <-chan mcp.QuestionRequest {
 	if r.stopped || r.mcp == nil {
 		return nil
 	}
-	return r.mcp.QuestionReq
+	return r.mcp.Question.Req
 }
 
 // SendQuestionResponse sends a response to a question request.
@@ -428,8 +428,8 @@ func (r *Runner) SendQuestionResponse(resp mcp.QuestionResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.QuestionResponse
-	if r.mcp != nil {
-		ch = r.mcp.QuestionResp
+	if r.mcp != nil && r.mcp.Question != nil {
+		ch = r.mcp.Question.Resp
 	}
 	r.mu.RUnlock()
 
@@ -452,7 +452,7 @@ func (r *Runner) PlanApprovalRequestChan() <-chan mcp.PlanApprovalRequest {
 	if r.stopped || r.mcp == nil {
 		return nil
 	}
-	return r.mcp.PlanReq
+	return r.mcp.PlanApproval.Req
 }
 
 // SendPlanApprovalResponse sends a response to a plan approval request.
@@ -461,8 +461,8 @@ func (r *Runner) SendPlanApprovalResponse(resp mcp.PlanApprovalResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.PlanApprovalResponse
-	if r.mcp != nil {
-		ch = r.mcp.PlanResp
+	if r.mcp != nil && r.mcp.PlanApproval != nil {
+		ch = r.mcp.PlanApproval.Resp
 	}
 	r.mu.RUnlock()
 
@@ -484,7 +484,7 @@ func (r *Runner) SetSupervisor(supervisor bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.supervisor = supervisor
-	if supervisor && r.mcp != nil && r.mcp.CreateChildReq == nil {
+	if supervisor && r.mcp != nil && r.mcp.CreateChild == nil {
 		r.mcp.InitSupervisorChannels()
 	}
 }
@@ -493,10 +493,10 @@ func (r *Runner) SetSupervisor(supervisor bool) {
 func (r *Runner) CreateChildRequestChan() <-chan mcp.CreateChildRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.CreateChild == nil {
 		return nil
 	}
-	return r.mcp.CreateChildReq
+	return r.mcp.CreateChild.Req
 }
 
 // SendCreateChildResponse sends a response to a create child request.
@@ -504,8 +504,8 @@ func (r *Runner) SendCreateChildResponse(resp mcp.CreateChildResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.CreateChildResponse
-	if r.mcp != nil {
-		ch = r.mcp.CreateChildResp
+	if r.mcp != nil && r.mcp.CreateChild != nil {
+		ch = r.mcp.CreateChild.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {
@@ -520,10 +520,10 @@ func (r *Runner) SendCreateChildResponse(resp mcp.CreateChildResponse) {
 func (r *Runner) ListChildrenRequestChan() <-chan mcp.ListChildrenRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.ListChildren == nil {
 		return nil
 	}
-	return r.mcp.ListChildrenReq
+	return r.mcp.ListChildren.Req
 }
 
 // SendListChildrenResponse sends a response to a list children request.
@@ -531,8 +531,8 @@ func (r *Runner) SendListChildrenResponse(resp mcp.ListChildrenResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.ListChildrenResponse
-	if r.mcp != nil {
-		ch = r.mcp.ListChildrenResp
+	if r.mcp != nil && r.mcp.ListChildren != nil {
+		ch = r.mcp.ListChildren.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {
@@ -547,10 +547,10 @@ func (r *Runner) SendListChildrenResponse(resp mcp.ListChildrenResponse) {
 func (r *Runner) MergeChildRequestChan() <-chan mcp.MergeChildRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.MergeChild == nil {
 		return nil
 	}
-	return r.mcp.MergeChildReq
+	return r.mcp.MergeChild.Req
 }
 
 // SendMergeChildResponse sends a response to a merge child request.
@@ -558,8 +558,8 @@ func (r *Runner) SendMergeChildResponse(resp mcp.MergeChildResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.MergeChildResponse
-	if r.mcp != nil {
-		ch = r.mcp.MergeChildResp
+	if r.mcp != nil && r.mcp.MergeChild != nil {
+		ch = r.mcp.MergeChild.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {
@@ -577,7 +577,7 @@ func (r *Runner) SetHostTools(hostTools bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.hostTools = hostTools
-	if hostTools && r.mcp != nil && r.mcp.CreatePRReq == nil {
+	if hostTools && r.mcp != nil && r.mcp.CreatePR == nil {
 		r.mcp.InitHostToolChannels()
 	}
 }
@@ -586,10 +586,10 @@ func (r *Runner) SetHostTools(hostTools bool) {
 func (r *Runner) CreatePRRequestChan() <-chan mcp.CreatePRRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.CreatePR == nil {
 		return nil
 	}
-	return r.mcp.CreatePRReq
+	return r.mcp.CreatePR.Req
 }
 
 // SendCreatePRResponse sends a response to a create PR request.
@@ -597,8 +597,8 @@ func (r *Runner) SendCreatePRResponse(resp mcp.CreatePRResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.CreatePRResponse
-	if r.mcp != nil {
-		ch = r.mcp.CreatePRResp
+	if r.mcp != nil && r.mcp.CreatePR != nil {
+		ch = r.mcp.CreatePR.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {
@@ -613,10 +613,10 @@ func (r *Runner) SendCreatePRResponse(resp mcp.CreatePRResponse) {
 func (r *Runner) PushBranchRequestChan() <-chan mcp.PushBranchRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.PushBranch == nil {
 		return nil
 	}
-	return r.mcp.PushBranchReq
+	return r.mcp.PushBranch.Req
 }
 
 // SendPushBranchResponse sends a response to a push branch request.
@@ -624,8 +624,8 @@ func (r *Runner) SendPushBranchResponse(resp mcp.PushBranchResponse) {
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.PushBranchResponse
-	if r.mcp != nil {
-		ch = r.mcp.PushBranchResp
+	if r.mcp != nil && r.mcp.PushBranch != nil {
+		ch = r.mcp.PushBranch.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {
@@ -640,10 +640,10 @@ func (r *Runner) SendPushBranchResponse(resp mcp.PushBranchResponse) {
 func (r *Runner) GetReviewCommentsRequestChan() <-chan mcp.GetReviewCommentsRequest {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.stopped || r.mcp == nil {
+	if r.stopped || r.mcp == nil || r.mcp.GetReviewComments == nil {
 		return nil
 	}
-	return r.mcp.GetReviewCommentsReq
+	return r.mcp.GetReviewComments.Req
 }
 
 // SendGetReviewCommentsResponse sends a response to a get review comments request.
@@ -651,8 +651,8 @@ func (r *Runner) SendGetReviewCommentsResponse(resp mcp.GetReviewCommentsRespons
 	r.mu.RLock()
 	stopped := r.stopped
 	var ch chan mcp.GetReviewCommentsResponse
-	if r.mcp != nil {
-		ch = r.mcp.GetReviewCommentsResp
+	if r.mcp != nil && r.mcp.GetReviewComments != nil {
+		ch = r.mcp.GetReviewComments.Resp
 	}
 	r.mu.RUnlock()
 	if stopped || ch == nil {

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -84,17 +84,11 @@ func TestNew(t *testing.T) {
 			if runner.mcp == nil {
 				t.Error("mcp is nil")
 			}
-			if runner.mcp.PermissionReq == nil {
-				t.Error("mcp.PermissionReq is nil")
+			if !runner.mcp.Permission.IsInitialized() {
+				t.Error("mcp.Permission is not initialized")
 			}
-			if runner.mcp.PermissionResp == nil {
-				t.Error("mcp.PermissionResp is nil")
-			}
-			if runner.mcp.QuestionReq == nil {
-				t.Error("mcp.QuestionReq is nil")
-			}
-			if runner.mcp.QuestionResp == nil {
-				t.Error("mcp.QuestionResp is nil")
+			if !runner.mcp.Question.IsInitialized() {
+				t.Error("mcp.Question is not initialized")
 			}
 		})
 	}
@@ -3408,7 +3402,7 @@ func TestRunner_SetSupervisor(t *testing.T) {
 
 	// Test send/receive on supervisor channels
 	go func() {
-		runner.mcp.CreateChildReq <- mcp.CreateChildRequest{ID: "test", Task: "do something"}
+		runner.mcp.CreateChild.Req <- mcp.CreateChildRequest{ID: "test", Task: "do something"}
 	}()
 
 	select {
@@ -3423,7 +3417,7 @@ func TestRunner_SetSupervisor(t *testing.T) {
 	// Test response sending
 	runner.SendCreateChildResponse(mcp.CreateChildResponse{ID: "test", Success: true, ChildID: "child-1"})
 	select {
-	case resp := <-runner.mcp.CreateChildResp:
+	case resp := <-runner.mcp.CreateChild.Resp:
 		if resp.ChildID != "child-1" {
 			t.Errorf("expected child-1, got %q", resp.ChildID)
 		}
@@ -3485,21 +3479,21 @@ func TestMCPChannels_SupervisorClose(t *testing.T) {
 	ch := NewMCPChannels()
 	ch.InitSupervisorChannels()
 
-	if ch.CreateChildReq == nil {
-		t.Error("expected non-nil CreateChildReq after InitSupervisorChannels")
+	if ch.CreateChild == nil {
+		t.Error("expected non-nil CreateChild after InitSupervisorChannels")
 	}
 
 	// Close should not panic and should nil out channels
 	ch.Close()
 
-	if ch.CreateChildReq != nil {
-		t.Error("expected nil CreateChildReq after Close")
+	if ch.CreateChild.IsInitialized() {
+		t.Error("expected CreateChild not initialized after Close")
 	}
-	if ch.ListChildrenReq != nil {
-		t.Error("expected nil ListChildrenReq after Close")
+	if ch.ListChildren.IsInitialized() {
+		t.Error("expected ListChildren not initialized after Close")
 	}
-	if ch.MergeChildReq != nil {
-		t.Error("expected nil MergeChildReq after Close")
+	if ch.MergeChild.IsInitialized() {
+		t.Error("expected MergeChild not initialized after Close")
 	}
 
 	// Double close should not panic

--- a/internal/claude/mcp_config.go
+++ b/internal/claude/mcp_config.go
@@ -44,20 +44,20 @@ func (r *Runner) ensureServerRunning() error {
 
 	// Build optional socket server options for supervisor channels
 	var socketOpts []mcp.SocketServerOption
-	if r.supervisor && r.mcp.CreateChildReq != nil {
+	if r.supervisor && r.mcp.CreateChild != nil {
 		socketOpts = append(socketOpts, mcp.WithSupervisorChannels(
-			r.mcp.CreateChildReq, r.mcp.CreateChildResp,
-			r.mcp.ListChildrenReq, r.mcp.ListChildrenResp,
-			r.mcp.MergeChildReq, r.mcp.MergeChildResp,
+			r.mcp.CreateChild.Req, r.mcp.CreateChild.Resp,
+			r.mcp.ListChildren.Req, r.mcp.ListChildren.Resp,
+			r.mcp.MergeChild.Req, r.mcp.MergeChild.Resp,
 		))
 	}
 
 	// Build optional socket server options for host tool channels
-	if r.hostTools && r.mcp.CreatePRReq != nil {
+	if r.hostTools && r.mcp.CreatePR != nil {
 		socketOpts = append(socketOpts, mcp.WithHostToolChannels(
-			r.mcp.CreatePRReq, r.mcp.CreatePRResp,
-			r.mcp.PushBranchReq, r.mcp.PushBranchResp,
-			r.mcp.GetReviewCommentsReq, r.mcp.GetReviewCommentsResp,
+			r.mcp.CreatePR.Req, r.mcp.CreatePR.Resp,
+			r.mcp.PushBranch.Req, r.mcp.PushBranch.Resp,
+			r.mcp.GetReviewComments.Req, r.mcp.GetReviewComments.Resp,
 		))
 	}
 
@@ -65,14 +65,14 @@ func (r *Runner) ensureServerRunning() error {
 		// Container sessions use TCP because Unix sockets don't work across
 		// the Docker container boundary.
 		socketServer, err = mcp.NewTCPSocketServer(r.sessionID,
-			r.mcp.PermissionReq, r.mcp.PermissionResp,
-			r.mcp.QuestionReq, r.mcp.QuestionResp,
-			r.mcp.PlanReq, r.mcp.PlanResp, socketOpts...)
+			r.mcp.Permission.Req, r.mcp.Permission.Resp,
+			r.mcp.Question.Req, r.mcp.Question.Resp,
+			r.mcp.PlanApproval.Req, r.mcp.PlanApproval.Resp, socketOpts...)
 	} else {
 		socketServer, err = mcp.NewSocketServer(r.sessionID,
-			r.mcp.PermissionReq, r.mcp.PermissionResp,
-			r.mcp.QuestionReq, r.mcp.QuestionResp,
-			r.mcp.PlanReq, r.mcp.PlanResp, socketOpts...)
+			r.mcp.Permission.Req, r.mcp.Permission.Resp,
+			r.mcp.Question.Req, r.mcp.Question.Resp,
+			r.mcp.PlanApproval.Req, r.mcp.PlanApproval.Resp, socketOpts...)
 	}
 	if err != nil {
 		r.log.Error("failed to create socket server", "error", err)

--- a/internal/mcp/channel_pair.go
+++ b/internal/mcp/channel_pair.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+)
+
+// ChannelPair groups a request and response channel for a single MCP operation.
+type ChannelPair[Req, Resp any] struct {
+	Req  chan Req
+	Resp chan Resp
+}
+
+// NewChannelPair creates a new ChannelPair with the given buffer size.
+func NewChannelPair[Req, Resp any](bufferSize int) *ChannelPair[Req, Resp] {
+	return &ChannelPair[Req, Resp]{
+		Req:  make(chan Req, bufferSize),
+		Resp: make(chan Resp, bufferSize),
+	}
+}
+
+// Close closes both channels. Safe to call on nil ChannelPair.
+func (cp *ChannelPair[Req, Resp]) Close() {
+	if cp == nil {
+		return
+	}
+	if cp.Req != nil {
+		close(cp.Req)
+		cp.Req = nil
+	}
+	if cp.Resp != nil {
+		close(cp.Resp)
+		cp.Resp = nil
+	}
+}
+
+// IsInitialized returns true if both channels are non-nil.
+func (cp *ChannelPair[Req, Resp]) IsInitialized() bool {
+	return cp != nil && cp.Req != nil && cp.Resp != nil
+}
+
+// handleChannelMessage is the generic handler for SocketServer channel-based messages.
+// It replaces the 6 identical handler methods (handleCreateChildMessage, etc.).
+func handleChannelMessage[Req, Resp any](
+	log *slog.Logger,
+	conn net.Conn,
+	req *Req,
+	reqCh chan<- Req,
+	respCh <-chan Resp,
+	responseTimeout time.Duration,
+	nilResp Resp,
+	timeoutResp func(interface{}) Resp,
+	getID func(*Req) interface{},
+	msgType MessageType,
+	setResp func(*SocketMessage, *Resp),
+	label string,
+) {
+	if req == nil || reqCh == nil {
+		log.Warn(label + " request ignored (nil request or no channel)")
+		sendResponse(log, conn, msgType, nilResp, setResp)
+		return
+	}
+
+	log.Info("received " + label + " request")
+
+	select {
+	case reqCh <- *req:
+	case <-time.After(SocketReadTimeout):
+		log.Warn("timeout sending " + label + " request to TUI")
+		resp := timeoutResp(getID(req))
+		sendResponse(log, conn, msgType, resp, setResp)
+		return
+	}
+
+	select {
+	case resp := <-respCh:
+		sendResponse(log, conn, msgType, resp, setResp)
+		log.Info("sent " + label + " response")
+	case <-time.After(responseTimeout):
+		log.Warn("timeout waiting for " + label + " response")
+		resp := timeoutResp(getID(req))
+		sendResponse(log, conn, msgType, resp, setResp)
+	}
+}
+
+// sendResponse is the generic response sender for SocketServer.
+// It replaces the 6 identical sendXxxResponse methods.
+func sendResponse[Resp any](
+	log *slog.Logger,
+	conn net.Conn,
+	msgType MessageType,
+	resp Resp,
+	setResp func(*SocketMessage, *Resp),
+) {
+	var msg SocketMessage
+	msg.Type = msgType
+	setResp(&msg, &resp)
+
+	respJSON, err := json.Marshal(msg)
+	if err != nil {
+		log.Error("failed to marshal response", "error", err)
+		return
+	}
+
+	conn.SetWriteDeadline(time.Now().Add(SocketWriteTimeout))
+	if _, err := conn.Write(append(respJSON, '\n')); err != nil {
+		log.Error("write error", "error", err)
+	}
+}
+
+// sendSocketRequest is the generic request sender for SocketClient.
+// It replaces the 9 identical SendXxxRequest methods.
+func sendSocketRequest[Req, Resp any](
+	c *SocketClient,
+	req Req,
+	msgType MessageType,
+	setReq func(*SocketMessage, *Req),
+	getResp func(*SocketMessage) *Resp,
+	readTimeout time.Duration, // 0 means no deadline
+	label string,
+) (Resp, error) {
+	var msg SocketMessage
+	msg.Type = msgType
+	setReq(&msg, &req)
+
+	reqJSON, err := json.Marshal(msg)
+	if err != nil {
+		var zero Resp
+		return zero, err
+	}
+
+	c.conn.SetWriteDeadline(time.Now().Add(SocketWriteTimeout))
+	if _, err = c.conn.Write(append(reqJSON, '\n')); err != nil {
+		var zero Resp
+		return zero, fmt.Errorf("write %s request: %w", label, err)
+	}
+
+	if readTimeout == 0 {
+		c.conn.SetReadDeadline(time.Time{})
+	} else {
+		c.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	}
+
+	line, err := c.reader.ReadString('\n')
+	if err != nil {
+		var zero Resp
+		return zero, fmt.Errorf("read %s response: %w", label, err)
+	}
+
+	var respMsg SocketMessage
+	if err := json.Unmarshal([]byte(line), &respMsg); err != nil {
+		var zero Resp
+		return zero, err
+	}
+
+	resp := getResp(&respMsg)
+	if resp == nil {
+		var zero Resp
+		return zero, fmt.Errorf("expected %s response, got nil", label)
+	}
+
+	return *resp, nil
+}
+
+// handleToolChannelRequest is the generic handler for Server tool channel requests.
+// It replaces the 6 identical tool handler channel send/receive/respond patterns.
+func handleToolChannelRequest[Req, Resp any](
+	s *Server,
+	reqID interface{},
+	req Req,
+	reqCh chan<- Req,
+	respCh <-chan Resp,
+	receiveTimeout time.Duration,
+	isError func(Resp) bool,
+	label string,
+) {
+	select {
+	case reqCh <- req:
+	case <-time.After(ChannelSendTimeout):
+		s.sendToolResult(reqID, true, `{"error":"TUI not responding"}`)
+		return
+	}
+
+	select {
+	case resp := <-respCh:
+		resultJSON, err := json.Marshal(resp)
+		if err != nil {
+			s.sendToolResult(reqID, true, `{"error":"failed to marshal response"}`)
+			return
+		}
+		s.sendToolResult(reqID, isError(resp), string(resultJSON))
+	case <-time.After(receiveTimeout):
+		s.sendToolResult(reqID, true, fmt.Sprintf(`{"error":"timeout waiting for %s"}`, label))
+	}
+}
+
+// ForwardRequests starts a goroutine that forwards requests from reqCh to sendFn
+// and sends responses back to respCh. On send errors, errRespFn is used to
+// generate a fallback response. Exported because it's used from cmd/mcp_server.go.
+func ForwardRequests[Req, Resp any](
+	wg *sync.WaitGroup,
+	reqCh <-chan Req,
+	respCh chan<- Resp,
+	sendFn func(Req) (Resp, error),
+	errRespFn func(Req) Resp,
+) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for req := range reqCh {
+			resp, err := sendFn(req)
+			if err != nil {
+				respCh <- errRespFn(req)
+			} else {
+				respCh <- resp
+			}
+		}
+	}()
+}

--- a/internal/mcp/channel_pair_test.go
+++ b/internal/mcp/channel_pair_test.go
@@ -1,0 +1,219 @@
+package mcp
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestNewChannelPair(t *testing.T) {
+	cp := NewChannelPair[int, string](1)
+	if cp == nil {
+		t.Fatal("NewChannelPair returned nil")
+	}
+	if cp.Req == nil {
+		t.Error("Req channel is nil")
+	}
+	if cp.Resp == nil {
+		t.Error("Resp channel is nil")
+	}
+
+	// Verify buffer size by sending without blocking
+	cp.Req <- 42
+	cp.Resp <- "hello"
+
+	got := <-cp.Req
+	if got != 42 {
+		t.Errorf("expected 42, got %d", got)
+	}
+	gotStr := <-cp.Resp
+	if gotStr != "hello" {
+		t.Errorf("expected hello, got %s", gotStr)
+	}
+}
+
+func TestNewChannelPairZeroBuffer(t *testing.T) {
+	cp := NewChannelPair[int, int](0)
+	if cp == nil {
+		t.Fatal("NewChannelPair returned nil")
+	}
+	if cp.Req == nil || cp.Resp == nil {
+		t.Error("channels should be non-nil even with zero buffer")
+	}
+}
+
+func TestChannelPairClose(t *testing.T) {
+	cp := NewChannelPair[int, string](1)
+
+	// Close should work
+	cp.Close()
+
+	if cp.Req != nil {
+		t.Error("Req should be nil after Close")
+	}
+	if cp.Resp != nil {
+		t.Error("Resp should be nil after Close")
+	}
+}
+
+func TestChannelPairCloseNil(t *testing.T) {
+	// Close on nil ChannelPair should not panic
+	var cp *ChannelPair[int, string]
+	cp.Close() // should be a no-op
+}
+
+func TestChannelPairCloseIdempotent(t *testing.T) {
+	cp := NewChannelPair[int, string](1)
+
+	// Double close should not panic
+	cp.Close()
+	cp.Close()
+}
+
+func TestChannelPairIsInitialized(t *testing.T) {
+	tests := []struct {
+		name     string
+		cp       *ChannelPair[int, string]
+		expected bool
+	}{
+		{
+			name:     "nil pair",
+			cp:       nil,
+			expected: false,
+		},
+		{
+			name:     "initialized pair",
+			cp:       NewChannelPair[int, string](1),
+			expected: true,
+		},
+		{
+			name: "nil Req channel",
+			cp: &ChannelPair[int, string]{
+				Req:  nil,
+				Resp: make(chan string, 1),
+			},
+			expected: false,
+		},
+		{
+			name: "nil Resp channel",
+			cp: &ChannelPair[int, string]{
+				Req:  make(chan int, 1),
+				Resp: nil,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cp.IsInitialized(); got != tt.expected {
+				t.Errorf("IsInitialized() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestChannelPairIsInitializedAfterClose(t *testing.T) {
+	cp := NewChannelPair[int, string](1)
+	if !cp.IsInitialized() {
+		t.Error("should be initialized before Close")
+	}
+
+	cp.Close()
+	if cp.IsInitialized() {
+		t.Error("should not be initialized after Close")
+	}
+}
+
+func TestForwardRequests(t *testing.T) {
+	reqCh := make(chan int, 3)
+	respCh := make(chan string, 3)
+
+	var wg sync.WaitGroup
+
+	ForwardRequests(&wg, reqCh, respCh,
+		func(req int) (string, error) {
+			return "ok", nil
+		},
+		func(req int) string {
+			return "error"
+		})
+
+	// Send requests
+	reqCh <- 1
+	reqCh <- 2
+	reqCh <- 3
+	close(reqCh)
+
+	wg.Wait()
+
+	// All responses should be "ok"
+	for i := 0; i < 3; i++ {
+		resp := <-respCh
+		if resp != "ok" {
+			t.Errorf("expected ok, got %s", resp)
+		}
+	}
+}
+
+func TestForwardRequestsWithErrors(t *testing.T) {
+	reqCh := make(chan int, 2)
+	respCh := make(chan string, 2)
+
+	var wg sync.WaitGroup
+
+	ForwardRequests(&wg, reqCh, respCh,
+		func(req int) (string, error) {
+			if req == 1 {
+				return "", errors.New("fail")
+			}
+			return "ok", nil
+		},
+		func(req int) string {
+			return "fallback"
+		})
+
+	// Send requests: first fails, second succeeds
+	reqCh <- 1
+	reqCh <- 2
+	close(reqCh)
+
+	wg.Wait()
+
+	resp1 := <-respCh
+	resp2 := <-respCh
+
+	if resp1 != "fallback" {
+		t.Errorf("expected fallback for failed request, got %s", resp1)
+	}
+	if resp2 != "ok" {
+		t.Errorf("expected ok for successful request, got %s", resp2)
+	}
+}
+
+func TestForwardRequestsEmptyChannel(t *testing.T) {
+	reqCh := make(chan int)
+	respCh := make(chan string, 1)
+
+	var wg sync.WaitGroup
+
+	ForwardRequests(&wg, reqCh, respCh,
+		func(req int) (string, error) {
+			return "ok", nil
+		},
+		func(req int) string {
+			return "error"
+		})
+
+	// Close immediately - goroutine should exit cleanly
+	close(reqCh)
+	wg.Wait()
+
+	// No responses should have been sent
+	select {
+	case resp := <-respCh:
+		t.Errorf("unexpected response: %s", resp)
+	default:
+		// Expected - no responses
+	}
+}


### PR DESCRIPTION
## Summary
Introduces a generic `ChannelPair[Req, Resp]` type to eliminate massive duplication across MCP channel management. Previously, every request/response channel pair (permission, question, plan approval, supervisor tools, host tools) was individually declared, initialized, nil-checked, and closed — resulting in hundreds of lines of repetitive boilerplate.

## Changes
- Add `internal/mcp/channel_pair.go` with generic `ChannelPair[Req, Resp]` struct, `NewChannelPair`, `Close`, and `IsInitialized` methods
- Add generic helpers: `handleChannelMessage`, `sendResponse`, `sendSocketRequest`, `handleToolChannelRequest`, and `ForwardRequests` to replace duplicated patterns across server, client, and forwarding code
- Refactor `MCPChannels` struct to use `*ChannelPair` instead of separate req/resp channel fields (18 fields → 9)
- Refactor `MCPChannels.Close()` from ~60 lines of nil-check-close-nil to 9 `Close()` calls
- Refactor `MockRunner` to use `ChannelPair` fields, consolidating its channel management and `Stop()` cleanup
- Refactor `cmd/mcp_server.go` forwarding goroutines to use `ForwardRequests` helper, eliminating 9 identical goroutine patterns
- Refactor `Server` tool handlers to use `handleToolChannelRequest` generic helper
- Refactor `SocketClient` send methods to use `sendSocketRequest` generic helper
- Refactor `SocketServer` message handlers to use `handleChannelMessage` generic helper
- Add comprehensive tests in `channel_pair_test.go` covering initialization, close semantics, nil safety, and `ForwardRequests`

## Test plan
- Run `go test ./internal/mcp/...` to verify new `ChannelPair` tests pass
- Run `go test ./internal/claude/...` to verify refactored channel access in runner and mock
- Run `go test ./...` to verify no regressions across the full project
- Verify nil `ChannelPair` safety (close on nil, `IsInitialized` on nil)
- Verify double-close does not panic

Fixes #260