### PR TITLE
fix: replace time.Sleep in tests with deterministic synchronization

### DIFF
--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -3211,8 +3211,10 @@ func TestRunner_StreamLogFile_NoRaceWithStop(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	started := make(chan struct{})
 	go func() {
 		defer wg.Done()
+		close(started) // signal we've started
 		for range 100 {
 			runner.handleProcessLine(line)
 		}
@@ -3220,8 +3222,7 @@ func TestRunner_StreamLogFile_NoRaceWithStop(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		// Give handleProcessLine a head start so calls overlap
-		time.Sleep(time.Millisecond)
+		<-started // wait for handleProcessLine goroutine to start
 		runner.Stop()
 	}()
 

--- a/internal/mcp/socket_test.go
+++ b/internal/mcp/socket_test.go
@@ -217,7 +217,7 @@ func TestSocketClientServer_Integration(t *testing.T) {
 	server.Start()
 
 	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	// Create client
 	client, err := NewSocketClient(server.SocketPath())
@@ -288,7 +288,7 @@ func TestSocketClientServer_Question(t *testing.T) {
 	// Start server
 	server.Start()
 
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	client, err := NewSocketClient(server.SocketPath())
 	if err != nil {
@@ -374,7 +374,7 @@ func TestSocketClientServer_PlanApproval(t *testing.T) {
 	// Start server
 	server.Start()
 
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	client, err := NewSocketClient(server.SocketPath())
 	if err != nil {
@@ -542,7 +542,7 @@ func TestTCPClientServer_Integration(t *testing.T) {
 	server.Start()
 
 	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	// Create TCP client
 	client, err := NewTCPSocketClient(server.TCPAddr())
@@ -609,7 +609,7 @@ func TestTCPClientServer_Question(t *testing.T) {
 	defer server.Close()
 
 	server.Start()
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	client, err := NewTCPSocketClient(server.TCPAddr())
 	if err != nil {
@@ -668,7 +668,7 @@ func TestTCPClientServer_PlanApproval(t *testing.T) {
 	defer server.Close()
 
 	server.Start()
-	time.Sleep(50 * time.Millisecond)
+	server.WaitReady()
 
 	client, err := NewTCPSocketClient(server.TCPAddr())
 	if err != nil {


### PR DESCRIPTION
## Summary
Eliminates flaky test timing by replacing `time.Sleep` calls with proper synchronization primitives.

## Changes
- Add `readyCh` channel to `SocketServer` so callers can deterministically wait for the server to be ready to accept connections
- Add `WaitReady()` method to `SocketServer` that blocks until the server's `Run()` loop begins
- Replace all `time.Sleep(50 * time.Millisecond)` calls in socket tests with `server.WaitReady()`
- Replace `time.Sleep(time.Millisecond)` in race condition test with a `started` channel for proper goroutine coordination

## Test plan
- Run `go test ./internal/mcp/ -race -count=5` to verify socket tests pass reliably without sleeps
- Run `go test ./internal/claude/ -race -count=5 -run TestRunner_StreamLogFile_NoRaceWithStop` to verify the race test is deterministic
- Run `go test ./...` to confirm no regressions

Fixes #267