### PR TITLE
docs: highlight headless agent mode on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>plural - parallel claude code sessions</title>
-    <meta name="description" content="Run multiple Claude Code sessions in parallel, each in its own git branch. Compare approaches, ship faster.">
+    <meta name="description" content="Run multiple Claude Code sessions in parallel, each in its own git branch. Or run fully headless — label a GitHub issue and let plural code, review, and merge autonomously.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -268,6 +268,87 @@
             font-size: 0.78rem;
             color: var(--text-muted);
             line-height: 1.6;
+        }
+
+        /* ── Headless ── */
+
+        .headless {
+            padding: 3rem 0;
+            border-top: 1px solid var(--border);
+        }
+
+        .headless-heading {
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+
+        .headless-heading h2 {
+            font-size: 1.2rem;
+            font-weight: 600;
+        }
+
+        .headless-heading p {
+            margin-top: 0.3rem;
+            font-size: 0.8rem;
+            color: var(--text-dim);
+        }
+
+        .headless-body {
+            max-width: 680px;
+            margin: 0 auto;
+        }
+
+        .headless-desc {
+            font-size: 0.82rem;
+            color: var(--text-muted);
+            line-height: 1.7;
+            margin-bottom: 1.25rem;
+            text-align: center;
+        }
+
+        .headless-desc code {
+            color: var(--secondary);
+            font-family: inherit;
+        }
+
+        .headless-cmd {
+            margin-bottom: 1.5rem;
+        }
+
+        .headless-steps {
+            list-style: none;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.75rem;
+        }
+
+        .headless-steps li {
+            background: var(--bg-elevated);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 0.75rem 1rem;
+            font-size: 0.78rem;
+            color: var(--text-muted);
+            line-height: 1.5;
+        }
+
+        .headless-steps li code {
+            color: var(--secondary);
+            font-family: inherit;
+        }
+
+        .headless-steps .hl {
+            display: block;
+            color: var(--primary);
+            font-weight: 700;
+            font-size: 0.7rem;
+            margin-bottom: 0.25rem;
+        }
+
+        @media (max-width: 600px) {
+            .headless-steps {
+                grid-template-columns: 1fr;
+            }
         }
 
         /* ── Install ── */
@@ -535,7 +616,7 @@
                 <img src="logo.svg" alt="plural" class="logo-svg">
             </div>
             <p class="hero-tagline fade-in">explore multiple solutions at once.</p>
-            <p class="hero-sub fade-in">run parallel Claude Code sessions, each in its own git branch. compare approaches side by side and ship faster.</p>
+            <p class="hero-sub fade-in">run parallel Claude Code sessions, each in its own git branch. compare approaches side by side and ship faster. or run fully headless — label a GitHub issue and let plural code, review, and merge autonomously.</p>
             <div class="hero-cta fade-in">
                 <a href="#install" class="btn btn-primary">install</a>
                 <a href="https://github.com/zhubert/plural" class="btn btn-secondary">view on github</a>
@@ -588,6 +669,11 @@
                     <h3>full TUI</h3>
                     <p>keyboard-driven terminal interface with sidebar navigation, streaming output, and inline permission prompts.</p>
                 </div>
+                <div class="feature-card fade-in">
+                    <span class="feature-icon" aria-hidden="true">~</span>
+                    <h3>headless agent mode</h3>
+                    <p>run as a fully autonomous daemon. polls GitHub issues, codes, opens PRs, addresses review comments, and auto-merges — no human required.</p>
+                </div>
             </div>
         </section>
     </div>
@@ -614,6 +700,29 @@
                     <h3>merge the winner</h3>
                     <p>compare results, merge the best solution back, and clean up the rest.</p>
                 </div>
+            </div>
+        </section>
+    </div>
+
+    <!-- Headless Agent Mode -->
+    <div class="container">
+        <section class="headless">
+            <div class="headless-heading fade-in">
+                <h2>headless agent mode</h2>
+                <p>fully autonomous end-to-end issue resolution</p>
+            </div>
+            <div class="headless-body fade-in">
+                <p class="headless-desc">run plural as a persistent daemon on your server or CI — no TUI, no human in the loop. point it at a GitHub repo, label issues <code>queued</code>, and plural handles everything: picks up the issue, writes the code, opens a PR, addresses review comments, and merges when approved.</p>
+                <div class="command-block headless-cmd">
+                    <button class="copy-btn" onclick="copyCommand(this, 'plural agent --repo owner/repo')">copy</button>
+                    <code><span class="prompt">$</span> plural agent --repo owner/repo</code>
+                </div>
+                <ul class="headless-steps">
+                    <li><span class="hl">01</span> labels issue <code>queued</code> → plural picks it up</li>
+                    <li><span class="hl">02</span> containerized Claude session writes the code on a new branch</li>
+                    <li><span class="hl">03</span> PR opened automatically when work is complete</li>
+                    <li><span class="hl">04</span> review comments auto-addressed, PR merged when CI passes</li>
+                </ul>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
Updates the landing page to prominently feature the headless agent mode, making it clear that plural can run as a fully autonomous daemon alongside its TUI mode.

## Changes
- Updated meta description and hero subtitle to mention headless/autonomous operation
- Added new "headless agent mode" feature card in the features grid
- Added dedicated "headless agent mode" section with description, CLI command, and 4-step workflow visualization
- Added responsive CSS styles for the new headless section (2-column grid on desktop, single column on mobile)

## Test plan
- Open `docs/index.html` in a browser and verify the new headless section renders correctly
- Check responsive layout at mobile breakpoints (< 600px) to confirm grid collapses to single column
- Verify the copy button works for the `plural agent --repo owner/repo` command
- Confirm no visual regressions in existing sections

Fixes #283