### PR TITLE
docs: remove Go Report Card badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Plural
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/zhubert/plural)](https://goreportcard.com/report/github.com/zhubert/plural)
-
 **Explore multiple solutions at once.** Parallel Claude Code sessions, or a fully autonomous agent.
 
 Plural is a TUI and headless agent for Claude Code. Run parallel sessions across branches and repos, fork when Claude offers competing approaches, import issues from GitHub/Asana/Linear, broadcast prompts across services, and create PRs—all from a keyboard-driven terminal interface. Or skip the TUI entirely and run `plural agent` as an autonomous daemon that picks up GitHub issues, writes code, opens PRs, addresses review comments, and merges.


### PR DESCRIPTION
## Summary
Removes the Go Report Card badge from the README.

## Changes
- Removed the Go Report Card badge and link from the top of README.md

## Test plan
- Verify README renders correctly without the badge

Fixes #293