### PR TITLE
feat(workflow): add github.comment_issue action

### DIFF
--- a/internal/agent/daemon.go
+++ b/internal/agent/daemon.go
@@ -637,6 +637,7 @@ func (d *Daemon) buildActionRegistry() *workflow.ActionRegistry {
 	registry.Register("github.create_pr", &CreatePRAction{daemon: d})
 	registry.Register("github.push", &PushAction{daemon: d})
 	registry.Register("github.merge", &MergeAction{daemon: d})
+	registry.Register("github.comment_issue", &CommentIssueAction{daemon: d})
 	return registry
 }
 

--- a/internal/agent/daemon_actions_test.go
+++ b/internal/agent/daemon_actions_test.go
@@ -1,0 +1,210 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/zhubert/plural/internal/config"
+	"github.com/zhubert/plural/internal/exec"
+	"github.com/zhubert/plural/internal/git"
+	"github.com/zhubert/plural/internal/workflow"
+)
+
+var errGHFailed = fmt.Errorf("gh: command failed")
+
+func TestCommentIssueAction_Execute_WorkItemNotFound(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	action := &CommentIssueAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "Hello!"})
+	ac := &workflow.ActionContext{
+		WorkItemID: "nonexistent",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure for missing work item")
+	}
+	if result.Error == nil {
+		t.Error("expected error for missing work item")
+	}
+}
+
+func TestCommentIssueAction_Execute_NonGitHubIssue(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	// Add a work item with Asana source — should succeed (no-op)
+	d.state.AddWorkItem(&WorkItem{
+		ID:       "item-1",
+		IssueRef: config.IssueRef{Source: "asana", ID: "task-abc"},
+	})
+
+	action := &CommentIssueAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "Hello!"})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if !result.Success {
+		t.Errorf("expected success (no-op) for non-github issue, got error: %v", result.Error)
+	}
+}
+
+func TestCommentIssueAction_Execute_InvalidIssueNumber(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+
+	// GitHub issue with non-numeric ID (invalid)
+	d.state.AddWorkItem(&WorkItem{
+		ID:       "item-1",
+		IssueRef: config.IssueRef{Source: "github", ID: "not-a-number"},
+	})
+
+	action := &CommentIssueAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "Hello!"})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure for invalid issue number")
+	}
+	if result.Error == nil {
+		t.Error("expected error for invalid issue number")
+	}
+}
+
+func TestCommentIssueAction_Execute_Success(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Mock `gh issue comment` to succeed
+	mockExec.AddPrefixMatch("gh", []string{"issue", "comment"}, exec.MockResponse{
+		Stdout: []byte("https://github.com/owner/repo/issues/42#issuecomment-1\n"),
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+	cfg.Repos = []string{"/test/repo"}
+
+	// Add session so repo path can be resolved
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+	})
+
+	action := &CommentIssueAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "Work has started on this issue."})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if !result.Success {
+		t.Errorf("expected success, got error: %v", result.Error)
+	}
+
+	// Verify gh issue comment was called
+	calls := mockExec.GetCalls()
+	found := false
+	for _, c := range calls {
+		if c.Name == "gh" && len(c.Args) >= 2 && c.Args[0] == "issue" && c.Args[1] == "comment" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected gh issue comment to be called")
+	}
+}
+
+func TestCommentIssueAction_Execute_EmptyBody(t *testing.T) {
+	cfg := testConfig()
+	d := testDaemon(cfg)
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+	})
+
+	action := &CommentIssueAction{daemon: d}
+	// Empty body — should fail
+	params := workflow.NewParamHelper(map[string]any{"body": ""})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure for empty comment body")
+	}
+	if result.Error == nil {
+		t.Error("expected error for empty comment body")
+	}
+}
+
+func TestCommentIssueAction_Execute_GhError(t *testing.T) {
+	cfg := testConfig()
+	mockExec := exec.NewMockExecutor(nil)
+
+	// Mock `gh issue comment` to fail
+	mockExec.AddPrefixMatch("gh", []string{"issue", "comment"}, exec.MockResponse{
+		Err: errGHFailed,
+	})
+
+	gitSvc := git.NewGitServiceWithExecutor(mockExec)
+	d := testDaemonWithExec(cfg, mockExec)
+	d.gitService = gitSvc
+	d.repoFilter = "/test/repo"
+
+	sess := testSession("sess-1")
+	cfg.AddSession(*sess)
+
+	d.state.AddWorkItem(&WorkItem{
+		ID:        "item-1",
+		IssueRef:  config.IssueRef{Source: "github", ID: "42"},
+		SessionID: "sess-1",
+	})
+
+	action := &CommentIssueAction{daemon: d}
+	params := workflow.NewParamHelper(map[string]any{"body": "Starting work!"})
+	ac := &workflow.ActionContext{
+		WorkItemID: "item-1",
+		Params:     params,
+	}
+
+	result := action.Execute(context.Background(), ac)
+
+	if result.Success {
+		t.Error("expected failure when gh CLI fails")
+	}
+	if result.Error == nil {
+		t.Error("expected error when gh CLI fails")
+	}
+}

--- a/internal/workflow/config.go
+++ b/internal/workflow/config.go
@@ -82,10 +82,11 @@ func (d Duration) MarshalYAML() (any, error) {
 
 // ValidActions is the set of recognized action names for task states.
 var ValidActions = map[string]bool{
-	"ai.code":          true,
-	"github.create_pr": true,
-	"github.push":      true,
-	"github.merge":     true,
+	"ai.code":               true,
+	"github.create_pr":      true,
+	"github.push":           true,
+	"github.merge":          true,
+	"github.comment_issue":  true,
 }
 
 // ValidEvents is the set of recognized event names for wait states.

--- a/internal/workflow/validate_test.go
+++ b/internal/workflow/validate_test.go
@@ -291,6 +291,90 @@ func TestValidate(t *testing.T) {
 			},
 			wantFields: []string{"states.x.type"},
 		},
+		{
+			name: "github.comment_issue missing params",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.body"},
+		},
+		{
+			name: "github.comment_issue missing body param",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"other": "value"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.body"},
+		},
+		{
+			name: "github.comment_issue empty body",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"body": ""}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.body"},
+		},
+		{
+			name: "github.comment_issue valid body",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"body": "Starting work on this issue!"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
+			name: "github.comment_issue valid file body path",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"body": "file:templates/comment.md"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: nil,
+		},
+		{
+			name: "github.comment_issue body absolute path",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"body": "file:/etc/passwd"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.body"},
+		},
+		{
+			name: "github.comment_issue body path traversal",
+			cfg: &Config{
+				Start:  "c",
+				Source: SourceConfig{Provider: "github", Filter: FilterConfig{Label: "q"}},
+				States: map[string]*State{
+					"c":    {Type: StateTypeTask, Action: "github.comment_issue", Params: map[string]any{"body": "file:../../etc/passwd"}, Next: "done"},
+					"done": {Type: StateTypeSucceed},
+				},
+			},
+			wantFields: []string{"states.c.params.body"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Adds a new `github.comment_issue` workflow action that posts comments on GitHub issues associated with work items. This enables workflows to automatically comment on issues at any stage (e.g., notifying that work has started).

## Changes
- Add `CommentIssueAction` struct and `Execute` method in `daemon_actions.go`
- Add `commentOnIssue` helper on `Daemon` that resolves repo path, renders the body template, and calls `GitService.CommentOnIssue`
- Register `github.comment_issue` in the daemon's action registry
- Add `github.comment_issue` to `ValidActions` in workflow config
- Add `validateCommentIssueParams` validation requiring a non-empty `body` param (supports inline text and `file:` paths with path traversal protection)
- Add comprehensive tests for the action (missing work item, non-GitHub issue no-op, invalid issue number, success, empty body, gh CLI error)
- Add validation tests (missing params, missing body, empty body, valid body, valid file path, absolute path rejection, path traversal rejection)

## Test plan
- Run `go test ./internal/agent/...` to verify action execution tests pass
- Run `go test ./internal/workflow/...` to verify validation tests pass
- Run `go test ./...` to confirm no regressions across the full suite

Fixes #296