### PR TITLE
docs: document github.comment_issue workflow action in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ states:
 | `github.create_pr` — open a pull request | `ci.complete` — CI checks have finished |
 | `github.push` — push to remote | |
 | `github.merge` — merge the PR | |
+| `github.comment_issue` — post a comment on the GitHub issue | |
+
+`github.comment_issue` requires a `body` param (required): the comment text to post. Supports inline strings or `file:` references (e.g. `body: "file:./comments/done.md"`). Non-GitHub issues are silently skipped.
 
 #### Customizing the graph
 


### PR DESCRIPTION
## Summary
Adds documentation for the new `github.comment_issue` workflow action to the README.

## Changes
- Added `github.comment_issue` to the workflow actions table
- Documented the required `body` param with support for inline strings and `file:` references
- Noted that non-GitHub issues are silently skipped

## Test plan
- Verify README renders correctly on GitHub
- Confirm documentation matches the implementation from commit f85b5f3

Fixes #298