### PR TITLE
fix: container image update check always reporting false positive

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -164,7 +164,7 @@ func getRemoteManifestDigest(ctx context.Context, image string) (string, error) 
 		"application/vnd.docker.distribution.manifest.v2+json",
 	}, ", ")
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{Timeout: imageUpdateCheckTimeout}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, manifestURL, nil)
 	if err != nil {
@@ -176,7 +176,7 @@ func getRemoteManifestDigest(ctx context.Context, image string) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("registry request failed: %w", err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	// If unauthorized, try to get a bearer token and retry.
 	if resp.StatusCode == http.StatusUnauthorized {
@@ -196,7 +196,7 @@ func getRemoteManifestDigest(ctx context.Context, image string) (string, error) 
 		if err != nil {
 			return "", fmt.Errorf("registry request failed: %w", err)
 		}
-		resp.Body.Close()
+		defer resp.Body.Close()
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -332,6 +332,13 @@ func TestParseImageRef(t *testing.T) {
 			wantTag:      "v2",
 		},
 		{
+			name:         "custom registry with port no tag",
+			image:        "myregistry.com:5000/myimage",
+			wantRegistry: "myregistry.com:5000",
+			wantRepo:     "myimage",
+			wantTag:      "latest",
+		},
+		{
 			name:         "nested repo path",
 			image:        "ghcr.io/org/team/image:sha-abc123",
 			wantRegistry: "ghcr.io",


### PR DESCRIPTION
## Summary
- The container image update check (`CheckContainerImageUpdate`) was always showing "update available" even when the image was up to date
- Root cause: `docker manifest inspect` returns **platform-specific** manifest digests, but the local `RepoDigests` stores the **manifest list** digest — these are inherently different for multi-arch images, so the comparison always mismatched
- Fix: Query the OCI registry API directly via HEAD request, which returns the `Docker-Content-Digest` header (the manifest list digest), matching what Docker stores locally
- Also handles registry auth via the standard OCI WWW-Authenticate → Bearer token flow

## Test plan
- [x] Unit tests for `parseImageRef` (GHCR, Docker Hub, custom registries)
- [x] Unit tests for `parseWWWAuthenticate` (GHCR and Docker Hub auth headers)
- [x] Existing tests still pass (`go test ./...`)
- [ ] Manual: verify no false positive alert on startup with up-to-date image
- [ ] Manual: verify alert appears when image is actually outdated

🤖 Generated with [Claude Code](https://claude.com/claude-code)