### PR TITLE
Adapt to plural-core v0.2.0 tool catalog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/zhubert/plural
 
 go 1.25.4
 
-require github.com/zhubert/plural-core v0.1.3
+require github.com/zhubert/plural-core v0.2.0
 
 require (
 	charm.land/bubbles/v2 v2.0.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/zhubert/plural-core v0.1.3 h1:9mGUacosXnhtswbnbmgnkeRwGO0MvY6LzoAHMQbg9s0=
 github.com/zhubert/plural-core v0.1.3/go.mod h1:nKmzzKU3perxjzAorsf1U9ttsfOic26j59zDbhFu6Jc=
+github.com/zhubert/plural-core v0.2.0 h1:VBps1BmesnqITXlAmEHEHJFRZJaJPs7HZOt0NNNoMAc=
+github.com/zhubert/plural-core v0.2.0/go.mod h1:nKmzzKU3perxjzAorsf1U9ttsfOic26j59zDbhFu6Jc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.design/x/clipboard v0.7.1 h1:OEG3CmcYRBNnRwpDp7+uWLiZi3hrMRJpE9JkkkYtz2c=
 golang.design/x/clipboard v0.7.1/go.mod h1:i5SiIqj0wLFw9P/1D7vfILFK0KHMk7ydE72HRrUIgkg=

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -880,6 +880,7 @@ func (m *Model) broadcastToSessions(sessions []config.Session, prompt string) (t
 		go func(sess config.Session) {
 			defer wg.Done()
 			runner := m.sessionMgr.GetOrCreateRunner(&sess)
+			m.sessionMgr.ConfigureRunnerDefaults(runner, &sess)
 			results <- runnerResult{sess: sess, runner: runner}
 		}(sess)
 	}


### PR DESCRIPTION
## Summary
- Bumps plural-core to v0.2.0 which introduces composable tool sets and splits `GetOrCreateRunner` from policy configuration
- Adds `ConfigureRunnerDefaults` call in the broadcast handler where `GetOrCreateRunner` is called directly (the main TUI path through `Select()` already handles this)

## Test plan
- [x] `go test ./...` passes in plural
- [x] Verified broadcast handler applies tools/container/streaming config via `ConfigureRunnerDefaults`

🤖 Generated with [Claude Code](https://claude.com/claude-code)