### PR TITLE
Auto-approve MCP server tools from Claude Code config

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/zhubert/plural/internal/changelog"
 	"github.com/zhubert/plural-core/claude"
+	"github.com/zhubert/plural/internal/claudeconfig"
 	"github.com/zhubert/plural/internal/clipboard"
 	"github.com/zhubert/plural-core/config"
 	"github.com/zhubert/plural-core/git"
@@ -1048,6 +1049,18 @@ func (m *Model) showCommitConflictModal() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// addClaudeCodeMCPApprovals discovers MCP servers from the user's Claude Code
+// config and auto-approves their tools so they don't trigger permission prompts.
+func (m *Model) addClaudeCodeMCPApprovals(runner claude.RunnerInterface, sess *config.Session) {
+	if runner == nil || sess == nil || sess.Containerized {
+		return
+	}
+	patterns := claudeconfig.DiscoverMCPToolPatterns(sess.RepoPath)
+	for _, pattern := range patterns {
+		runner.AddAllowedTool(pattern)
+	}
+}
+
 func (m *Model) selectSession(sess *config.Session) {
 	if sess == nil {
 		return
@@ -1066,6 +1079,8 @@ func (m *Model) selectSession(sess *config.Session) {
 	if result == nil {
 		return
 	}
+
+	m.addClaudeCodeMCPApprovals(result.Runner, sess)
 
 	// Update app state
 	m.activeSession = sess

--- a/internal/app/modal_handlers_issues.go
+++ b/internal/app/modal_handlers_issues.go
@@ -296,6 +296,8 @@ func (m *Model) createSessionsFromIssues(repoPath string, selectedIssues []ui.Is
 				continue
 			}
 
+			m.addClaudeCodeMCPApprovals(result.Runner, sess)
+
 			runner := result.Runner
 
 			// Start streaming for this session
@@ -456,6 +458,8 @@ func (m *Model) createParallelSessions(selectedOptions []ui.OptionItem) (tea.Mod
 				logger.WithSession(sess.ID).Error("failed to get runner for parallel session")
 				continue
 			}
+
+			m.addClaudeCodeMCPApprovals(result.Runner, sess)
 
 			runner := result.Runner
 

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -818,6 +818,8 @@ func (m *Model) createBroadcastSessions(repoPaths []string, prompt string, sessi
 			continue
 		}
 
+		m.addClaudeCodeMCPApprovals(result.Runner, sess)
+
 		runner := result.Runner
 		sessionID := sess.ID
 
@@ -881,6 +883,7 @@ func (m *Model) broadcastToSessions(sessions []config.Session, prompt string) (t
 			defer wg.Done()
 			runner := m.sessionMgr.GetOrCreateRunner(&sess)
 			m.sessionMgr.ConfigureRunnerDefaults(runner, &sess)
+			m.addClaudeCodeMCPApprovals(runner, &sess)
 			results <- runnerResult{sess: sess, runner: runner}
 		}(sess)
 	}

--- a/internal/claudeconfig/mcp.go
+++ b/internal/claudeconfig/mcp.go
@@ -1,0 +1,92 @@
+package claudeconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/zhubert/plural-core/logger"
+)
+
+type claudeJSON struct {
+	Projects map[string]projectConfig `json:"projects"`
+}
+
+type projectConfig struct {
+	MCPServers map[string]json.RawMessage `json:"mcpServers"`
+}
+
+// DiscoverMCPToolPatterns reads the user's Claude Code MCP configuration
+// from ~/.claude.json and <repoPath>/.mcp.json, and returns tool approval
+// patterns (e.g., "mcp__myserver__*") for each discovered server name.
+// All errors are logged but swallowed (best-effort).
+func DiscoverMCPToolPatterns(repoPath string) []string {
+	return discoverMCPToolPatterns(repoPath, "")
+}
+
+// discoverMCPToolPatterns is the internal implementation that accepts a homeDir
+// override for testing. If homeDir is empty, os.UserHomeDir() is used.
+func discoverMCPToolPatterns(repoPath, homeDir string) []string {
+	log := logger.Get()
+	seen := make(map[string]bool)
+	var patterns []string
+
+	// Resolve symlinks for repoPath to match against ~/.claude.json keys
+	resolvedRepo := repoPath
+	if resolved, err := filepath.EvalSymlinks(repoPath); err == nil {
+		resolvedRepo = resolved
+	}
+
+	// Source 1: ~/.claude.json -> projects[repoPath].mcpServers
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			log.Debug("failed to get home dir for MCP discovery", "error", err)
+			return nil
+		}
+	}
+
+	claudeJSONPath := filepath.Join(homeDir, ".claude.json")
+	if data, err := os.ReadFile(claudeJSONPath); err == nil {
+		var cfg claudeJSON
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			log.Debug("failed to parse ~/.claude.json for MCP discovery", "error", err)
+		} else {
+			// Try both the original and resolved repo path
+			for _, key := range []string{resolvedRepo, repoPath} {
+				if proj, ok := cfg.Projects[key]; ok {
+					for name := range proj.MCPServers {
+						if !seen[name] {
+							seen[name] = true
+							patterns = append(patterns, fmt.Sprintf("mcp__%s__*", name))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Source 2: <repoPath>/.mcp.json (top-level keys are server names)
+	mcpJSONPath := filepath.Join(repoPath, ".mcp.json")
+	if data, err := os.ReadFile(mcpJSONPath); err == nil {
+		var servers map[string]json.RawMessage
+		if err := json.Unmarshal(data, &servers); err != nil {
+			log.Debug("failed to parse .mcp.json for MCP discovery", "error", err)
+		} else {
+			for name := range servers {
+				if !seen[name] {
+					seen[name] = true
+					patterns = append(patterns, fmt.Sprintf("mcp__%s__*", name))
+				}
+			}
+		}
+	}
+
+	if len(patterns) > 0 {
+		log.Info("discovered MCP tool patterns for auto-approval", "patterns", patterns)
+	}
+
+	return patterns
+}

--- a/internal/claudeconfig/mcp_test.go
+++ b/internal/claudeconfig/mcp_test.go
@@ -1,0 +1,194 @@
+package claudeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestDiscoverMCPToolPatterns(t *testing.T) {
+	tests := []struct {
+		name         string
+		claudeJSON   string   // contents for ~/.claude.json (empty = don't create)
+		mcpJSON      string   // contents for <repo>/.mcp.json (empty = don't create)
+		useSymlink   bool     // pass a symlink path as repoPath
+		wantPatterns []string // expected patterns (sorted)
+	}{
+		{
+			name:         "no config files",
+			wantPatterns: nil,
+		},
+		{
+			name: "claude.json with project mcpServers",
+			claudeJSON: `{
+				"projects": {
+					"REPO_PATH": {
+						"mcpServers": {
+							"filesystem": {"command": "npx", "args": ["fs-server"]},
+							"github": {"command": "gh", "args": ["mcp"]}
+						}
+					}
+				}
+			}`,
+			wantPatterns: []string{"mcp__filesystem__*", "mcp__github__*"},
+		},
+		{
+			name: "mcp.json with servers",
+			mcpJSON: `{
+				"sqlite": {"command": "npx", "args": ["sqlite-mcp"]},
+				"postgres": {"command": "pg-mcp"}
+			}`,
+			wantPatterns: []string{"mcp__postgres__*", "mcp__sqlite__*"},
+		},
+		{
+			name: "both sources merged and deduplicated",
+			claudeJSON: `{
+				"projects": {
+					"REPO_PATH": {
+						"mcpServers": {
+							"shared-server": {"command": "shared"},
+							"claude-only": {"command": "only-in-claude"}
+						}
+					}
+				}
+			}`,
+			mcpJSON: `{
+				"shared-server": {"command": "shared"},
+				"repo-only": {"command": "only-in-repo"}
+			}`,
+			wantPatterns: []string{"mcp__claude-only__*", "mcp__repo-only__*", "mcp__shared-server__*"},
+		},
+		{
+			name:         "malformed claude.json",
+			claudeJSON:   `{not valid json`,
+			wantPatterns: nil,
+		},
+		{
+			name:         "malformed mcp.json",
+			mcpJSON:      `[1, 2, 3]`,
+			wantPatterns: nil,
+		},
+		{
+			name: "repo path not found in projects",
+			claudeJSON: `{
+				"projects": {
+					"/some/other/repo": {
+						"mcpServers": {
+							"other": {"command": "other"}
+						}
+					}
+				}
+			}`,
+			wantPatterns: nil,
+		},
+		{
+			name: "claude.json project with no mcpServers key",
+			claudeJSON: `{
+				"projects": {
+					"REPO_PATH": {
+						"allowedTools": ["tool1"]
+					}
+				}
+			}`,
+			wantPatterns: nil,
+		},
+		{
+			name: "symlinked repo path matches claude.json",
+			claudeJSON: `{
+				"projects": {
+					"RESOLVED_PATH": {
+						"mcpServers": {
+							"symlink-server": {"command": "test"}
+						}
+					}
+				}
+			}`,
+			useSymlink:   true,
+			wantPatterns: []string{"mcp__symlink-server__*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp home dir
+			homeDir := t.TempDir()
+
+			// Create temp repo dir
+			repoDir := t.TempDir()
+
+			// Write ~/.claude.json if specified
+			if tt.claudeJSON != "" {
+				// Replace REPO_PATH placeholder with actual repo path
+				content := tt.claudeJSON
+
+				if tt.useSymlink {
+					// For symlink tests, use a symlink as repoPath but
+					// register the fully resolved path in claude.json
+					// (on macOS, /tmp is a symlink to /private/tmp)
+					resolvedPath, err := filepath.EvalSymlinks(repoDir)
+					if err != nil {
+						t.Fatalf("failed to resolve repo dir: %v", err)
+					}
+					content = replaceAll(content, "RESOLVED_PATH", resolvedPath)
+
+					// Create a symlink to the repo dir
+					symlinkDir := t.TempDir()
+					symlinkPath := filepath.Join(symlinkDir, "linked-repo")
+					if err := os.Symlink(repoDir, symlinkPath); err != nil {
+						t.Fatalf("failed to create symlink: %v", err)
+					}
+					repoDir = symlinkPath
+				} else {
+					content = replaceAll(content, "REPO_PATH", repoDir)
+				}
+
+				if err := os.WriteFile(filepath.Join(homeDir, ".claude.json"), []byte(content), 0644); err != nil {
+					t.Fatalf("failed to write claude.json: %v", err)
+				}
+			}
+
+			// Write <repo>/.mcp.json if specified
+			if tt.mcpJSON != "" {
+				if err := os.WriteFile(filepath.Join(repoDir, ".mcp.json"), []byte(tt.mcpJSON), 0644); err != nil {
+					t.Fatalf("failed to write .mcp.json: %v", err)
+				}
+			}
+
+			got := discoverMCPToolPatterns(repoDir, homeDir)
+
+			// Sort for stable comparison
+			sort.Strings(got)
+			sort.Strings(tt.wantPatterns)
+
+			if len(got) != len(tt.wantPatterns) {
+				t.Fatalf("got %d patterns %v, want %d patterns %v", len(got), got, len(tt.wantPatterns), tt.wantPatterns)
+			}
+
+			for i := range got {
+				if got[i] != tt.wantPatterns[i] {
+					t.Errorf("pattern[%d] = %q, want %q", i, got[i], tt.wantPatterns[i])
+				}
+			}
+		})
+	}
+}
+
+func replaceAll(s, old, new string) string {
+	for {
+		i := indexOf(s, old)
+		if i < 0 {
+			return s
+		}
+		s = s[:i] + new + s[i+len(old):]
+	}
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
- Reads `~/.claude.json` project `mcpServers` and repo `.mcp.json` to discover user-configured MCP server names
- Auto-adds `mcp__<name>__*` patterns to the runner's allowed tools list on session start
- Prevents permission prompt timeouts when Claude CLI uses MCP tools from these servers

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/claudeconfig/...` — 9 table-driven tests (no configs, each source individually, merged/deduped, malformed JSON, missing repo path, symlinks)
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)