### PR TITLE
refactor: move container_image from global to per-repo config

### DIFF
--- a/internal/app/modal_handlers_config.go
+++ b/internal/app/modal_handlers_config.go
@@ -210,15 +210,6 @@ func (m *Model) handleSettingsModal(key string, msg tea.KeyPressMsg, state *ui.S
 		m.config.SetDefaultBranchPrefix(state.GetBranchPrefix())
 		m.config.SetNotificationsEnabled(state.GetNotificationsEnabled())
 		m.config.SetAutoCleanupMerged(state.AutoCleanupMerged)
-		// Save container image if containers are supported.
-		if state.ContainersSupported {
-			containerImage := state.GetContainerImage()
-			if containerImage != "" && !ui.ValidateContainerImage(containerImage) {
-				m.modal.SetError("Invalid container image name")
-				return m, nil
-			}
-			m.config.SetContainerImage(containerImage)
-		}
 		// Apply theme if changed
 		if state.ThemeChanged() {
 			selectedTheme := ui.GetSelectedSettingsTheme(state)

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -23,8 +23,9 @@ import (
 
 // ContainerImageBuiltMsg is sent when the async container image build completes.
 type ContainerImageBuiltMsg struct {
-	Tag string // The image tag that was built (or empty on error)
-	Err error  // Non-nil if the build failed
+	Tag      string // The image tag that was built (or empty on error)
+	Err      error  // Non-nil if the build failed
+	RepoPath string // The repo this image was built for
 }
 
 // checkContainerPrerequisitesAsync launches an async check of container prerequisites,
@@ -78,7 +79,7 @@ func (m *Model) handleContainerPrereqCheckMsg(msg ContainerPrereqCheckMsg) (tea.
 	expectedTag := container.ImageTag(container.GenerateDockerfile(langs, version))
 
 	// If the stored image matches the expected tag, use it directly
-	storedImage := m.config.GetContainerImage()
+	storedImage := m.config.GetContainerImage(repoPath)
 	if storedImage == expectedTag {
 		if m.pendingContainerAction != nil {
 			action := m.pendingContainerAction
@@ -92,7 +93,7 @@ func (m *Model) handleContainerPrereqCheckMsg(msg ContainerPrereqCheckMsg) (tea.
 	// Clear stale image so we don't keep trying to use it.
 	if storedImage != "" {
 		logger.Get().Info("stored container image is stale, rebuilding", "stored", storedImage, "expected", expectedTag)
-		m.config.SetContainerImage("")
+		m.config.SetContainerImage(repoPath, "")
 	}
 
 	// Show building modal with detected languages
@@ -110,7 +111,7 @@ func (m *Model) handleContainerPrereqCheckMsg(msg ContainerPrereqCheckMsg) (tea.
 	// Build image async (EnsureImage checks docker cache internally)
 	return m, tea.Batch(buildingState.Spinner.Tick, func() tea.Msg {
 		tag, err := container.EnsureImage(ctx, langs, version)
-		return ContainerImageBuiltMsg{Tag: tag, Err: err}
+		return ContainerImageBuiltMsg{Tag: tag, Err: err, RepoPath: repoPath}
 	})
 }
 
@@ -128,8 +129,8 @@ func (m *Model) handleContainerImageBuiltMsg(msg ContainerImageBuiltMsg) (tea.Mo
 		return m, nil
 	}
 
-	// Store the auto-built image tag
-	m.config.SetContainerImage(msg.Tag)
+	// Store the auto-built image tag for this repo
+	m.config.SetContainerImage(msg.RepoPath, msg.Tag)
 
 	// Execute the pending action
 	if m.pendingContainerAction != nil {

--- a/internal/app/modal_integration_test.go
+++ b/internal/app/modal_integration_test.go
@@ -551,7 +551,6 @@ func TestSettingsModal_Open(t *testing.T) {
 	m.modal.Show(ui.NewSettingsState(
 		cfg.GetDefaultBranchPrefix(),
 		cfg.GetNotificationsEnabled(),
-		false, "",
 		false,
 	))
 	if !m.modal.IsVisible() {
@@ -572,7 +571,6 @@ func TestSettingsModal_CancelWithEscape(t *testing.T) {
 	m.modal.Show(ui.NewSettingsState(
 		cfg.GetDefaultBranchPrefix(),
 		cfg.GetNotificationsEnabled(),
-		false, "",
 		false,
 	))
 	state := m.modal.State.(*ui.SettingsState)
@@ -601,7 +599,6 @@ func TestSettingsModal_ToggleNotifications(t *testing.T) {
 	m.modal.Show(ui.NewSettingsState(
 		cfg.GetDefaultBranchPrefix(),
 		cfg.GetNotificationsEnabled(),
-		false, "",
 		false,
 	))
 	state := m.modal.State.(*ui.SettingsState)
@@ -727,7 +724,6 @@ func TestSettingsModal_UpdatesBranchPrefix(t *testing.T) {
 	m.modal.Show(ui.NewSettingsState(
 		cfg.GetDefaultBranchPrefix(),
 		cfg.GetNotificationsEnabled(),
-		false, "",
 		false,
 	))
 	state := m.modal.State.(*ui.SettingsState)

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -699,8 +699,6 @@ func shortcutGlobalSettings(m *Model) (tea.Model, tea.Cmd) {
 	settingsState := ui.NewSettingsState(
 		m.config.GetDefaultBranchPrefix(),
 		m.config.GetNotificationsEnabled(),
-		process.ContainersSupported(),
-		m.config.GetContainerImage(),
 		m.config.GetAutoCleanupMerged(),
 	)
 	m.modal.Show(settingsState)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,8 @@ type Config struct {
 	RepoAllowedTools  map[string][]string    `json:"repo_allowed_tools,omitempty"`   // Per-repo allowed tools
 	RepoSquashOnMerge map[string]bool        `json:"repo_squash_on_merge,omitempty"` // Per-repo squash-on-merge setting
 	RepoAsanaProject  map[string]string      `json:"repo_asana_project,omitempty"`   // Per-repo Asana project GID mapping
-	RepoLinearTeam    map[string]string      `json:"repo_linear_team,omitempty"`     // Per-repo Linear team ID mapping
-	ContainerImage    string                 `json:"container_image,omitempty"`      // Container image for containerized sessions
+	RepoLinearTeam      map[string]string `json:"repo_linear_team,omitempty"`       // Per-repo Linear team ID mapping
+	RepoContainerImage map[string]string `json:"repo_container_image,omitempty"`   // Per-repo container image mapping
 
 	WelcomeShown         bool   `json:"welcome_shown,omitempty"`         // Whether welcome modal has been shown
 	LastSeenVersion      string `json:"last_seen_version,omitempty"`     // Last version user has seen changelog for
@@ -123,6 +123,9 @@ func (c *Config) ensureInitialized() {
 	}
 	if c.RepoLinearTeam == nil {
 		c.RepoLinearTeam = make(map[string]string)
+	}
+	if c.RepoContainerImage == nil {
+		c.RepoContainerImage = make(map[string]string)
 	}
 }
 
@@ -445,19 +448,31 @@ func (c *Config) HasLinearTeam(repoPath string) bool {
 	return c.GetLinearTeam(repoPath) != ""
 }
 
-// GetContainerImage returns the container image name.
+// GetContainerImage returns the container image name for a repo.
 // An empty string means auto-detect (auto-provision a container based on repo languages).
-func (c *Config) GetContainerImage() string {
+func (c *Config) GetContainerImage(repoPath string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.ContainerImage
+	if c.RepoContainerImage == nil {
+		return ""
+	}
+	resolved := resolveRepoPath(c.Repos, repoPath)
+	return c.RepoContainerImage[resolved]
 }
 
-// SetContainerImage sets the container image name
-func (c *Config) SetContainerImage(image string) {
+// SetContainerImage sets the container image name for a repo
+func (c *Config) SetContainerImage(repoPath, image string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.ContainerImage = image
+	if c.RepoContainerImage == nil {
+		c.RepoContainerImage = make(map[string]string)
+	}
+	resolved := resolveRepoPath(c.Repos, repoPath)
+	if image == "" {
+		delete(c.RepoContainerImage, resolved)
+	} else {
+		c.RepoContainerImage[resolved] = image
+	}
 }
 
 // GetAutoMaxTurns returns the max autonomous turns, defaulting to 50

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1773,23 +1773,31 @@ func TestConfig_ContainerImage(t *testing.T) {
 		Repos:    []string{"/path/to/repo"},
 		Sessions: []Session{},
 	}
+	cfg.ensureInitialized()
+
+	repoPath := "/path/to/repo"
 
 	// Default should be empty (auto-detect)
-	if got := cfg.GetContainerImage(); got != "" {
+	if got := cfg.GetContainerImage(repoPath); got != "" {
 		t.Errorf("GetContainerImage default = %q, want empty string", got)
 	}
 
-	// Set custom image
-	cfg.SetContainerImage("my-custom-image")
+	// Set custom image for a repo
+	cfg.SetContainerImage(repoPath, "my-custom-image")
 
-	if got := cfg.GetContainerImage(); got != "my-custom-image" {
+	if got := cfg.GetContainerImage(repoPath); got != "my-custom-image" {
 		t.Errorf("GetContainerImage = %q, want 'my-custom-image'", got)
 	}
 
-	// Set empty string should return empty (auto-detect mode)
-	cfg.SetContainerImage("")
+	// Different repo should return empty
+	if got := cfg.GetContainerImage("/path/to/other-repo"); got != "" {
+		t.Errorf("GetContainerImage for different repo = %q, want empty string", got)
+	}
 
-	if got := cfg.GetContainerImage(); got != "" {
+	// Set empty string should return empty (auto-detect mode)
+	cfg.SetContainerImage(repoPath, "")
+
+	if got := cfg.GetContainerImage(repoPath); got != "" {
 		t.Errorf("GetContainerImage after clearing = %q, want empty string", got)
 	}
 }
@@ -1804,12 +1812,14 @@ func TestConfig_ContainerImage_Persistence(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, "config.json")
 
-	// Create config with container settings
+	repoPath := "/path/to/repo"
+
+	// Create config with per-repo container settings
 	cfg := &Config{
-		Repos:          []string{"/path/to/repo"},
-		Sessions:       []Session{},
-		ContainerImage: "my-image",
-		filePath:       configPath,
+		Repos:              []string{repoPath},
+		Sessions:           []Session{},
+		RepoContainerImage: map[string]string{repoPath: "my-image"},
+		filePath:           configPath,
 	}
 
 	// Save the config
@@ -1828,8 +1838,52 @@ func TestConfig_ContainerImage_Persistence(t *testing.T) {
 		t.Fatalf("Failed to unmarshal config: %v", err)
 	}
 
-	if loaded.ContainerImage != "my-image" {
-		t.Errorf("ContainerImage = %q, want 'my-image'", loaded.ContainerImage)
+	if loaded.RepoContainerImage[repoPath] != "my-image" {
+		t.Errorf("RepoContainerImage[%q] = %q, want 'my-image'", repoPath, loaded.RepoContainerImage[repoPath])
+	}
+}
+
+func TestConfig_ContainerImage_MigrationFromGlobal(t *testing.T) {
+	// Simulate loading a config with the old global container_image field.
+	// The old field should be silently ignored (not cause errors).
+	tmpDir, err := os.MkdirTemp("", "plural-container-migration-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Override HOME so Load() finds our config
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	paths.Reset()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		paths.Reset()
+	}()
+
+	// Write a config with the old global container_image field
+	pluralDir := filepath.Join(tmpDir, ".plural")
+	if err := os.MkdirAll(pluralDir, 0755); err != nil {
+		t.Fatalf("Failed to create plural dir: %v", err)
+	}
+	configJSON := `{
+		"repos": ["/path/to/repo"],
+		"sessions": [],
+		"container_image": "old-global-image"
+	}`
+	configPath := filepath.Join(pluralDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load should succeed with old container_image field: %v", err)
+	}
+
+	// The old global image should not be accessible via per-repo API
+	if got := cfg.GetContainerImage("/path/to/repo"); got != "" {
+		t.Errorf("GetContainerImage should return empty for migrated config, got %q", got)
 	}
 }
 

--- a/internal/manager/session_manager.go
+++ b/internal/manager/session_manager.go
@@ -70,7 +70,7 @@ type SessionManagerConfig interface {
 	GetSessions() []config.Session
 	GetAllowedToolsForRepo(repoPath string) []string
 	GetMCPServersForRepo(repoPath string) []config.MCPServer
-	GetContainerImage() string
+	GetContainerImage(repoPath string) string
 	AddRepoAllowedTool(repoPath, tool string) bool
 	Save() error
 }
@@ -402,7 +402,7 @@ func (sm *SessionManager) ConfigureRunnerDefaults(runner claude.RunnerInterface,
 
 	// Configure container mode if enabled for this session
 	if sess.Containerized {
-		runner.SetContainerized(true, sm.config.GetContainerImage())
+		runner.SetContainerized(true, sm.config.GetContainerImage(sess.RepoPath))
 		// Set callback to clear container init state when container is ready
 		sessionID := sess.ID
 		runner.SetOnContainerReady(func() {

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -141,13 +141,11 @@ func themeKeysAndNames() ([]string, []string) {
 
 // NewSettingsState creates a new SettingsState with theme data injected automatically.
 func NewSettingsState(currentBranchPrefix string, notificationsEnabled bool,
-	containersSupported bool, containerImage string,
 	autoCleanupMerged bool) *SettingsState {
 	themeKeys, themeDisplayNames := themeKeysAndNames()
 	currentTheme := string(CurrentThemeName())
 	return modals.NewSettingsState(themeKeys, themeDisplayNames, currentTheme,
 		currentBranchPrefix, notificationsEnabled,
-		containersSupported, containerImage,
 		autoCleanupMerged)
 }
 

--- a/internal/ui/modals/config.go
+++ b/internal/ui/modals/config.go
@@ -238,8 +238,6 @@ type SettingsState struct {
 	branchPrefix         string
 	NotificationsEnabled bool
 	AutoCleanupMerged    bool // Auto-cleanup sessions when PR merged/closed
-	containerImage       string
-	ContainersSupported  bool // Whether Docker is available for container mode
 
 	// MultiSelect bindings
 	generalOptions []string
@@ -307,11 +305,6 @@ func (s *SettingsState) GetNotificationsEnabled() bool {
 	return s.NotificationsEnabled
 }
 
-// GetContainerImage returns the container image name, or empty string if unchanged/empty.
-func (s *SettingsState) GetContainerImage() string {
-	return strings.TrimSpace(s.containerImage)
-}
-
 // GetSelectedTheme returns the selected theme key.
 func (s *SettingsState) GetSelectedTheme() string {
 	return s.selectedTheme
@@ -348,7 +341,6 @@ func renderSectionHeader(title string) string {
 // NewSettingsState creates a new SettingsState with the current settings values.
 func NewSettingsState(themes []string, themeDisplayNames []string, currentTheme string,
 	currentBranchPrefix string, notificationsEnabled bool,
-	containersSupported bool, containerImage string,
 	autoCleanupMerged bool) *SettingsState {
 
 	s := &SettingsState{
@@ -357,8 +349,6 @@ func NewSettingsState(themes []string, themeDisplayNames []string, currentTheme 
 		branchPrefix:         currentBranchPrefix,
 		NotificationsEnabled: notificationsEnabled,
 		AutoCleanupMerged:    autoCleanupMerged,
-		containerImage:       containerImage,
-		ContainersSupported:  containersSupported,
 		availableWidth:       ModalWidthWide,
 	}
 
@@ -402,17 +392,7 @@ func NewSettingsState(themes []string, themeDisplayNames []string, currentTheme 
 			Value(&s.generalOptions),
 	)
 
-	// Container settings group (conditionally shown)
-	containerGroup := huh.NewGroup(
-		huh.NewInput().
-			Title("Container image").
-			Description("Image name used for container mode sessions").
-			Placeholder("auto-detect (leave empty)").
-			CharLimit(200).
-			Value(&s.containerImage),
-	).WithHideFunc(func() bool { return !containersSupported })
-
-	s.form = huh.NewForm(generalGroup, containerGroup).
+	s.form = huh.NewForm(generalGroup).
 		WithTheme(ModalTheme()).
 		WithShowHelp(false).
 		WithWidth(s.contentWidth()).

--- a/internal/ui/modals/config_test.go
+++ b/internal/ui/modals/config_test.go
@@ -17,42 +17,25 @@ var (
 // newTestSettingsState is a helper that prepends theme data to NewSettingsState calls.
 func newTestSettingsState(branchPrefix string, notifs bool) *SettingsState {
 	return NewSettingsState(testThemes, testThemeNames, testCurrentTheme,
-		branchPrefix, notifs, false, "", false)
-}
-
-// newTestSettingsStateWithContainers is like newTestSettingsState but with container support.
-func newTestSettingsStateWithContainers(branchPrefix string, notifs bool,
-	containersSupported bool, containerImage string) *SettingsState {
-	return NewSettingsState(testThemes, testThemeNames, testCurrentTheme,
-		branchPrefix, notifs, containersSupported, containerImage, false)
+		branchPrefix, notifs, false)
 }
 
 // =============================================================================
 // SettingsState (global settings) tests
 // =============================================================================
 
-func TestSettingsState_Render_NoContainerSection_WhenUnsupported(t *testing.T) {
+func TestSettingsState_Render_GeneralSettings(t *testing.T) {
 	s := newTestSettingsState("", false)
 
-	if s.ContainersSupported {
-		t.Error("ContainersSupported should be false")
-	}
-
-	// General settings should render correctly even without container support
 	rendered := s.Render()
 	for _, expected := range []string{"Settings", "Theme", "Default branch prefix", "Options"} {
 		if !strings.Contains(rendered, expected) {
 			t.Errorf("should contain %q in rendered output", expected)
 		}
 	}
-}
-
-func TestSettingsState_Render_ContainerSection_WhenSupported(t *testing.T) {
-	s := newTestSettingsStateWithContainers("", false, true, "plural-claude")
-	rendered := s.Render()
-
-	if !strings.Contains(rendered, "Container image") {
-		t.Error("Container image field should appear when containers supported")
+	// Container image should not appear (moved to per-repo)
+	if strings.Contains(rendered, "Container image") {
+		t.Error("Container image field should not appear in global settings")
 	}
 }
 
@@ -89,28 +72,6 @@ func TestSettingsState_Render_ContainsThemeSection(t *testing.T) {
 	}
 }
 
-func TestSettingsState_GetContainerImage(t *testing.T) {
-	s := newTestSettingsStateWithContainers("", false, true, "my-image")
-	if img := s.GetContainerImage(); img != "my-image" {
-		t.Errorf("Expected container image 'my-image', got %q", img)
-	}
-}
-
-func TestSettingsState_GetContainerImage_Default(t *testing.T) {
-	s := newTestSettingsStateWithContainers("", false, true, "")
-	if img := s.GetContainerImage(); img != "" {
-		t.Errorf("Expected empty container image, got %q", img)
-	}
-}
-
-func TestSettingsState_Render_ContainerImageValue(t *testing.T) {
-	s := newTestSettingsStateWithContainers("", false, true, "custom-image")
-	rendered := s.Render()
-
-	if !strings.Contains(rendered, "Container image") {
-		t.Error("Should show container image label")
-	}
-}
 
 func TestSettingsState_GetBranchPrefix(t *testing.T) {
 	s := newTestSettingsState("my-prefix/", false)
@@ -160,17 +121,6 @@ func TestSettingsState_Title(t *testing.T) {
 	}
 }
 
-func TestSettingsState_ContainersSupported(t *testing.T) {
-	s := newTestSettingsState("", false)
-	if s.ContainersSupported {
-		t.Error("ContainersSupported should be false without containers")
-	}
-
-	s2 := newTestSettingsStateWithContainers("", false, true, "")
-	if !s2.ContainersSupported {
-		t.Error("ContainersSupported should be true with containers")
-	}
-}
 
 // =============================================================================
 // NewSessionState tests (unchanged)


### PR DESCRIPTION
## Summary
- Moves `container_image` from a single global setting to per-repo storage (`repo_container_image` map keyed by repo path)
- Different repos have different dependencies, so a single global image caused the wrong image to be used when switching between repos
- Removes container image field from the global Settings modal (it's now managed automatically per-repo during container builds)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Register 2 repos with different languages, create container sessions for each, verify different images are built/stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)