### PR TITLE
Use mise for container language versions, add no-test system prompt

### DIFF
--- a/internal/app/modal_handlers.go
+++ b/internal/app/modal_handlers.go
@@ -71,7 +71,6 @@ func (m *Model) handleModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleContainerCommandModal(key, s)
 	case *ui.ContainerBuildingState:
 		return m.handleContainerBuildingModal(key, s)
-
 	// Navigation modals (modal_handlers_navigation.go)
 	case *ui.WelcomeState:
 		return m.handleWelcomeModal(key, msg, s)

--- a/internal/app/modal_handlers_session.go
+++ b/internal/app/modal_handlers_session.go
@@ -606,12 +606,11 @@ func (m *Model) createForkSession(repoPath, parentSessionID, branchName, branchP
 	m.sidebar.SetSessions(m.getFilteredSessions())
 	m.sidebar.SelectSession(sess.ID)
 	m.selectSession(sess)
+	m.modal.Hide()
 
 	if messageCopyFailed {
-		m.modal.Hide()
 		return m, m.ShowFlashWarning("Session created but conversation history could not be copied")
 	}
-	m.modal.Hide()
 	return m, nil
 }
 

--- a/internal/claude/mock_runner.go
+++ b/internal/claude/mock_runner.go
@@ -53,6 +53,9 @@ type MockRunner struct {
 	// Fork tracking
 	forkFromSessionID string
 
+	// System prompt
+	systemPrompt string
+
 	// Simulated streaming content for GetMessagesWithStreaming
 	streamingContent string
 
@@ -384,7 +387,16 @@ func (m *MockRunner) SetDisableStreamingChunks(disable bool) {
 
 // SetSystemPrompt implements RunnerInterface.
 func (m *MockRunner) SetSystemPrompt(prompt string) {
-	// No-op for mock
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.systemPrompt = prompt
+}
+
+// GetSystemPrompt returns the system prompt set on this mock runner.
+func (m *MockRunner) GetSystemPrompt() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.systemPrompt
 }
 
 // PermissionRequestChan implements RunnerInterface.

--- a/internal/container/build.go
+++ b/internal/container/build.go
@@ -125,9 +125,15 @@ func GenerateDockerfile(langs []DetectedLang, version string) string {
 		b.WriteString("\n\n")
 	}
 
+	// Install mise and languages if needed
+	miseBlock := miseInstallBlock(langs)
+	if miseBlock != "" {
+		b.WriteString(miseBlock)
+	}
+
 	// Entrypoint script (embedded inline)
 	// Runs as root: updates Claude CLI, copies host config selectively, fixes permissions,
-	// then switches to claude user and execs `claude` with the passed arguments.
+	// activates mise if installed, then switches to claude user and execs `claude`.
 	b.WriteString("RUN printf '#!/bin/bash\\nset -e\\n")
 	b.WriteString("# Update Claude CLI if possible\\n")
 	b.WriteString("if [ -z \"$PLURAL_SKIP_UPDATE\" ]; then\\n")
@@ -157,12 +163,15 @@ func GenerateDockerfile(langs []DetectedLang, version string) string {
 
 // languageInstallBlock returns the apk add fragment for a given language.
 // Returns empty string for languages that don't need extra packages (e.g., Node is the base image).
+// Ruby and Python are installed via mise (see miseInstallBlock), not apk.
 func languageInstallBlock(lang Language) string {
 	switch lang {
-	case LangPython:
-		return " \\\n    python3 \\\n    py3-pip"
 	case LangRuby:
-		return " \\\n    ruby \\\n    ruby-dev \\\n    build-base"
+		// build-base needed for native gem extensions; Ruby itself installed via mise
+		return " \\\n    build-base \\\n    linux-headers \\\n    yaml-dev \\\n    zlib-dev \\\n    openssl-dev \\\n    readline-dev"
+	case LangPython:
+		// Build deps for Python; Python itself installed via mise
+		return " \\\n    build-base \\\n    zlib-dev \\\n    bzip2-dev \\\n    xz-dev \\\n    readline-dev \\\n    sqlite-dev \\\n    openssl-dev \\\n    libffi-dev"
 	case LangRust:
 		return " \\\n    cargo \\\n    rust"
 	case LangJava:
@@ -170,6 +179,48 @@ func languageInstallBlock(lang Language) string {
 	default:
 		return ""
 	}
+}
+
+// miseLanguages are languages that should be installed via mise instead of apk.
+var miseLanguages = map[Language]bool{
+	LangRuby:   true,
+	LangPython: true,
+}
+
+// miseInstallBlock generates Dockerfile commands to install mise and use it to
+// install the correct versions of Ruby, Python, etc. as the claude user.
+// Returns empty string if no mise-managed languages are detected.
+func miseInstallBlock(langs []DetectedLang) string {
+	var installs []string
+	for _, l := range langs {
+		if !miseLanguages[l.Language] {
+			continue
+		}
+		version := l.Version
+		if version == "" {
+			version = defaultVersions[l.Language]
+		}
+		installs = append(installs, fmt.Sprintf("%s@%s", l.Language, version))
+	}
+	if len(installs) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	// Install mise and languages as the claude user via su-exec.
+	// su-exec avoids USER directive for legacy docker build compatibility.
+	// HOME must be set explicitly since su-exec doesn't set it.
+	b.WriteString("RUN HOME=/home/claude su-exec claude sh -c 'curl -fsSL https://mise.run | sh'\n\n")
+
+	// Install languages via mise as claude user
+	for _, install := range installs {
+		fmt.Fprintf(&b, "RUN HOME=/home/claude su-exec claude /home/claude/.local/bin/mise use --global %s\n", install)
+	}
+	// Add mise shims to PATH for all subsequent commands and the entrypoint
+	b.WriteString("ENV PATH=\"/home/claude/.local/share/mise/shims:$PATH\"\n\n")
+
+	return b.String()
 }
 
 // pluralDownloadBlock generates the RUN command to download the plural binary.

--- a/internal/container/build_test.go
+++ b/internal/container/build_test.go
@@ -53,11 +53,16 @@ func TestGenerateDockerfile_PythonOnly(t *testing.T) {
 	langs := []DetectedLang{{Language: LangPython, Version: "3.12"}}
 	df := GenerateDockerfile(langs, "v1.0.0")
 
-	if !strings.Contains(df, "python3") {
-		t.Error("expected python3 package")
+	// Python installed via mise, not apk
+	if !strings.Contains(df, "mise use --global python@3.12") {
+		t.Error("expected mise install of python@3.12")
 	}
-	if !strings.Contains(df, "py3-pip") {
-		t.Error("expected py3-pip package")
+	if !strings.Contains(df, "mise.run") {
+		t.Error("expected mise installation")
+	}
+	// Build deps still via apk
+	if !strings.Contains(df, "build-base") {
+		t.Error("expected build-base for Python compilation")
 	}
 }
 
@@ -65,12 +70,14 @@ func TestGenerateDockerfile_RubyOnly(t *testing.T) {
 	langs := []DetectedLang{{Language: LangRuby, Version: "3.2"}}
 	df := GenerateDockerfile(langs, "v1.0.0")
 
-	if !strings.Contains(df, "ruby") {
-		t.Error("expected ruby package")
+	// Ruby installed via mise, not apk
+	if !strings.Contains(df, "mise use --global ruby@3.2") {
+		t.Error("expected mise install of ruby@3.2")
 	}
-	if !strings.Contains(df, "ruby-dev") {
-		t.Error("expected ruby-dev package")
+	if !strings.Contains(df, "mise.run") {
+		t.Error("expected mise installation")
 	}
+	// Build deps still via apk
 	if !strings.Contains(df, "build-base") {
 		t.Error("expected build-base for native extensions")
 	}
@@ -110,8 +117,8 @@ func TestGenerateDockerfile_MultiLanguage(t *testing.T) {
 	if !strings.Contains(df, "golang:1.22-alpine") {
 		t.Error("expected Go builder stage")
 	}
-	if !strings.Contains(df, "python3") {
-		t.Error("expected Python packages")
+	if !strings.Contains(df, "mise use --global python@3.12") {
+		t.Error("expected mise install of Python")
 	}
 	if !strings.Contains(df, "gopls") {
 		t.Error("expected gopls")
@@ -361,8 +368,8 @@ func TestLanguageInstallBlock(t *testing.T) {
 		want    string
 		notWant string
 	}{
-		{LangPython, "python3", ""},
-		{LangRuby, "ruby-dev", ""},
+		{LangPython, "build-base", "python3"},
+		{LangRuby, "build-base", "ruby-dev"},
 		{LangRust, "cargo", ""},
 		{LangJava, "openjdk17", ""},
 		{LangNode, "", "nodejs"}, // Node is base image, no extra packages
@@ -409,4 +416,71 @@ func TestPluralDownloadBlock(t *testing.T) {
 			t.Error("release version should not use /latest/download/")
 		}
 	})
+}
+
+func TestMiseInstallBlock_RubyAndPython(t *testing.T) {
+	langs := []DetectedLang{
+		{Language: LangRuby, Version: "3.3"},
+		{Language: LangPython, Version: "3.12"},
+	}
+	block := miseInstallBlock(langs)
+
+	if !strings.Contains(block, "mise.run") {
+		t.Error("expected mise installation via mise.run")
+	}
+	if !strings.Contains(block, "mise use --global ruby@3.3") {
+		t.Error("expected mise use ruby@3.3")
+	}
+	if !strings.Contains(block, "mise use --global python@3.12") {
+		t.Error("expected mise use python@3.12")
+	}
+	if !strings.Contains(block, "mise/shims") {
+		t.Error("expected mise shims on PATH")
+	}
+	// mise installed and run as claude user via su-exec (legacy builder compat)
+	if !strings.Contains(block, "su-exec claude sh -c 'curl -fsSL https://mise.run") {
+		t.Error("expected mise installed as claude user via su-exec")
+	}
+	if !strings.Contains(block, "su-exec claude /home/claude/.local/bin/mise use") {
+		t.Error("expected mise invoked with full path as claude user")
+	}
+}
+
+func TestMiseInstallBlock_NoMiseLanguages(t *testing.T) {
+	langs := []DetectedLang{
+		{Language: LangGo, Version: "1.22"},
+		{Language: LangNode, Version: "20"},
+	}
+	block := miseInstallBlock(langs)
+
+	if block != "" {
+		t.Errorf("expected empty block for non-mise languages, got %q", block)
+	}
+}
+
+func TestMiseInstallBlock_DefaultVersion(t *testing.T) {
+	langs := []DetectedLang{
+		{Language: LangRuby}, // No version detected
+	}
+	block := miseInstallBlock(langs)
+
+	if !strings.Contains(block, "mise use --global ruby@3.2") {
+		t.Error("expected default ruby version 3.2")
+	}
+}
+
+func TestMiseInstallBlock_Empty(t *testing.T) {
+	block := miseInstallBlock(nil)
+	if block != "" {
+		t.Error("expected empty block for nil langs")
+	}
+}
+
+func TestGenerateDockerfile_MiseShimsInPath(t *testing.T) {
+	langs := []DetectedLang{{Language: LangRuby, Version: "3.3"}}
+	df := GenerateDockerfile(langs, "v1.0.0")
+
+	if !strings.Contains(df, "mise/shims") {
+		t.Error("expected mise shims directory in PATH")
+	}
 }

--- a/internal/manager/session_manager.go
+++ b/internal/manager/session_manager.go
@@ -22,6 +22,11 @@ import (
 // Compile-time interface satisfaction check.
 var _ SessionManagerConfig = (*config.Config)(nil)
 
+// containerSystemPrompt is appended to the system prompt for containerized sessions.
+// It guides Claude to focus on code changes and skip test execution since the container
+// environment lacks databases, credentials, and services needed to run tests.
+const containerSystemPrompt = `You are running inside a container with language tools (via mise) for editing code, but WITHOUT databases, external services, credentials, or other infrastructure needed to run tests or start the application. Do NOT attempt to run tests, start servers, or execute the application. Focus on writing and editing code. Tests will be run by CI after you push your changes.`
+
 // DiffStats holds file change statistics for the header display
 type DiffStats struct {
 	FilesChanged int
@@ -403,6 +408,7 @@ func (sm *SessionManager) ConfigureRunnerDefaults(runner claude.RunnerInterface,
 	// Configure container mode if enabled for this session
 	if sess.Containerized {
 		runner.SetContainerized(true, sm.config.GetContainerImage(sess.RepoPath))
+		runner.SetSystemPrompt(containerSystemPrompt)
 		// Set callback to clear container init state when container is ready
 		sessionID := sess.ID
 		runner.SetOnContainerReady(func() {

--- a/internal/manager/session_manager_test.go
+++ b/internal/manager/session_manager_test.go
@@ -1186,3 +1186,57 @@ func TestConfigureRunnerDefaults_NonDaemonManaged_GetsHostTools(t *testing.T) {
 		t.Error("non-daemon-managed autonomous supervisor session SHOULD have host tools enabled")
 	}
 }
+
+func TestConfigureRunnerDefaults_ContainerSystemPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repos: []string{"/test/repo"},
+		Sessions: []config.Session{
+			{
+				ID:            "container-session",
+				RepoPath:      "/test/repo",
+				WorkTree:      "/test/worktree",
+				Containerized: true,
+			},
+		},
+		AllowedTools:     []string{},
+		RepoAllowedTools: make(map[string][]string),
+	}
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("container-session", false, nil)
+	sess := sm.GetSession("container-session")
+	sm.ConfigureRunnerDefaults(runner, sess)
+
+	prompt := runner.GetSystemPrompt()
+	if prompt == "" {
+		t.Fatal("containerized session should have a system prompt set")
+	}
+	if !strings.Contains(prompt, "Do NOT attempt to run tests") {
+		t.Error("container system prompt should instruct Claude not to run tests")
+	}
+}
+
+func TestConfigureRunnerDefaults_NonContainerNoSystemPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Repos: []string{"/test/repo"},
+		Sessions: []config.Session{
+			{
+				ID:       "host-session",
+				RepoPath: "/test/repo",
+				WorkTree: "/test/worktree",
+			},
+		},
+		AllowedTools:     []string{},
+		RepoAllowedTools: make(map[string][]string),
+	}
+	sm := NewSessionManager(cfg, git.NewGitService())
+
+	runner := claude.NewMockRunner("host-session", false, nil)
+	sess := sm.GetSession("host-session")
+	sm.ConfigureRunnerDefaults(runner, sess)
+
+	prompt := runner.GetSystemPrompt()
+	if prompt != "" {
+		t.Errorf("non-containerized session should not have a system prompt, got %q", prompt)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace apk-based Ruby/Python installs with **mise** in generated container Dockerfiles, so the exact version from `.ruby-version`/`.python-version` is respected
- Add a container-specific system prompt telling Claude not to run tests (no DB/services/credentials) and to rely on CI
- Remove the earlier `bin/setup` auto-send approach (host-side setup scripts don't belong in containers)

## Test plan
- [x] All existing container build tests updated and passing
- [x] New tests for `miseInstallBlock` (Ruby+Python, no-mise languages, default version, empty)
- [x] New tests for container system prompt (set for containerized, not set for host)
- [ ] Manual: create a containerized session for a Ruby repo, verify `ruby --version` matches `.ruby-version`
- [ ] Manual: verify Claude does not attempt to run tests in container sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)