### PR TITLE
docs: add Linear integration, new features, and workflow CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ plural --version          # Show version
 plural help               # Show help
 plural clean              # Remove sessions, logs, worktrees, and containers
 plural clean -y           # Clean without confirmation
+
+plural workflow init      # Scaffold .plural/workflow.yaml for current repo
+plural workflow validate  # Validate .plural/workflow.yaml
+plural workflow visualize # Generate mermaid workflow diagram
 ```
 
 ## Data Storage

--- a/docs/index.html
+++ b/docs/index.html
@@ -617,8 +617,8 @@
             <span class="feature-icon" aria-hidden="true">#</span>
             <h3>issue integration</h3>
             <p>
-              connect GitHub Issues or Asana tasks. start a session directly
-              from a ticket, branch named and ready to go.
+              connect GitHub Issues, Asana tasks, or Linear issues. start a
+              session directly from a ticket, branch named and ready to go.
             </p>
           </div>
           <div class="feature-card">
@@ -635,6 +635,30 @@
             <p>
               keyboard-driven terminal interface with sidebar navigation,
               streaming output, and inline permission prompts.
+            </p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon" aria-hidden="true">~&gt;</span>
+            <h3>fork &amp; compare</h3>
+            <p>
+              fork any session into parallel branches when Claude offers
+              competing approaches. auto-detect options with Ctrl+O.
+            </p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon" aria-hidden="true">*&gt;</span>
+            <h3>broadcast</h3>
+            <p>
+              send a prompt to every registered repo at once. apply migrations,
+              bump dependencies, or enforce patterns across a fleet.
+            </p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon" aria-hidden="true">::</span>
+            <h3>workflow config</h3>
+            <p>
+              define per-repo workflows in <code style="font-size:0.75rem;color:var(--accent)">.plural/workflow.yaml</code>
+              — custom system prompts, hooks, and max-turn limits.
             </p>
           </div>
         </div>
@@ -681,7 +705,7 @@
           <p>
             check out
             <a
-              href="https://zhubert.com/plural-agent"
+              href="https://github.com/zhubert/plural-agent"
               style="
                 color: var(--accent);
                 text-decoration: none;


### PR DESCRIPTION
## Summary
Updates documentation site and README to reflect recent feature additions including Linear issue integration, fork & compare, broadcast, and workflow configuration.

## Changes
- Add `workflow init`, `workflow validate`, and `workflow visualize` CLI commands to README
- Add Linear as a supported issue provider alongside GitHub Issues and Asana
- Add three new feature cards to docs site: fork & compare, broadcast, and workflow config
- Fix broken link to plural-agent repo

## Test plan
- Verify README renders correctly with new CLI commands section
- Open `docs/index.html` locally and confirm the three new feature cards display properly
- Confirm the plural-agent link points to the correct GitHub URL

Fixes #313