### PR TITLE
docs: fix documentation inaccuracies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,24 @@ tail -f ~/.plural/logs/stream-*.log    # Raw Claude stream messages (per-session
 main.go                    Entry point, calls cmd.Execute()
 cmd/                       CLI commands (Cobra)
 internal/
-├── app/                   Main Bubble Tea model (app.go, shortcuts.go, session_manager.go, modal_handlers*.go)
+├── app/                   Main Bubble Tea model (app.go, shortcuts.go, modal_handlers*.go)
+├── changelog/             Changelog management for GitHub releases
 ├── claude/                Claude CLI wrapper (runner in claude.go, process in process_manager.go)
+├── claudeconfig/          Claude CLI configuration helpers
+├── cli/                   CLI prerequisites checking
+├── clipboard/             Cross-platform clipboard operations
 ├── config/                Config and session structs, persists to ~/.plural/ or XDG dirs
-├── demo/                  Demo recording infrastructure (scenarios in demo/scenarios/)
+├── container/             Container build and detection
 ├── exec/                  CommandExecutor interface (RealExecutor, MockExecutor)
 ├── git/                   GitService - all git operations with context propagation
-├── issues/                Issue providers (GitHub via gh CLI, Asana via REST API)
+├── issues/                Issue providers (GitHub via gh CLI, Asana via REST API, Linear via GraphQL)
 ├── keys/                  Key string constants for Bubble Tea v2 key events
+├── logger/                Structured logging framework
+├── manager/               SessionManager - runner lifecycle and session state
 ├── mcp/                   MCP server for permission prompts via Unix socket IPC
+├── notification/          Notification handling
 ├── paths/                 XDG Base Directory path resolution
+├── plugins/               Plugin system support
 ├── process/               Find/kill orphaned Claude processes and Docker containers
 ├── session/               SessionService - worktree creation/management
 ├── ui/                    Bubble Tea UI components (chat, sidebar, header, footer, modals/)
@@ -79,7 +87,7 @@ Default: `~/.plural/`. Supports XDG Base Directory Specification (see `internal/
 - **Bubble Tea Model-Update-View** with `tea.Msg` for events
 - **Focus system**: Tab switches between sidebar and chat
 - **Streaming**: Claude responses stream via channel as `ClaudeResponseMsg`
-- **Runner caching**: Claude runners cached by session ID in `claudeRunners` map
+- **Runner caching**: Claude runners cached by session ID in `runners` map (in `SessionManager`)
 - **Thread-safe config**: Uses `sync.RWMutex`
 - **State machine**: `AppState` enum (StateIdle, StateStreamingClaude)
 - **Service pattern**: `GitService` and `SessionService` use explicit dependency injection with `CommandExecutor` interface for testability. All I/O methods take `context.Context` as first param. Use `NewXxxServiceWithExecutor()` for mocking in tests.
@@ -115,7 +123,7 @@ To add a new shortcut:
 ### Permission System
 
 1. Claude CLI started with `--permission-prompt-tool mcp__plural__permission`
-2. MCP server communicates with TUI via Unix socket (`/tmp/plural-<session-id>.sock`)
+2. MCP server communicates with TUI via Unix socket (`/tmp/pl-<shortID>.sock`, first 12 chars of session ID)
 3. Permission prompts appear inline in chat (y/n/a responses)
 4. Allowed tools: defaults + global (`allowed_tools`) + per-repo (`repo_allowed_tools`)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Auth: `ANTHROPIC_API_KEY` env var, macOS keychain (`anthropic_api_key`), OAuth t
 - **Tool use rollup** (`Ctrl+T`) — toggle collapsed/expanded tool operations
 - **Log viewer** (`Ctrl+L`) — debug, MCP, and stream logs
 - **Cost tracking** (`/cost`) — token usage and estimated cost
-- **8 themes** — press `t` to switch (tokyo-night, dracula, nord, gruvbox, catppuccin, and more)
+- **8 themes** — switch via settings (tokyo-night, dracula, nord, gruvbox, catppuccin, and more)
 - **MCP servers and plugins** (`/mcp`, `/plugins`)
 - **Per-repo settings** for allowed tools, squash-on-merge, and issue provider mapping
 - **Settings** — global with `Alt+,`, per-session with `,`

--- a/docs/index.html
+++ b/docs/index.html
@@ -655,10 +655,10 @@
           </div>
           <div class="feature-card">
             <span class="feature-icon" aria-hidden="true">::</span>
-            <h3>workflow config</h3>
+            <h3>per-repo settings</h3>
             <p>
-              define per-repo workflows in <code style="font-size:0.75rem;color:var(--accent)">.plural/workflow.yaml</code>
-              — custom system prompts, hooks, and max-turn limits.
+              configure allowed tools, squash-on-merge, and issue provider
+              mapping per repository via the settings modal.
             </p>
           </div>
         </div>
@@ -753,7 +753,7 @@
         <div class="footer-links">
           <a href="https://github.com/zhubert/plural">github</a>
           <a href="https://github.com/zhubert/plural/issues">issues</a>
-          <a href="https://github.com/zhubert/plural#usage">docs</a>
+          <a href="https://github.com/zhubert/plural#quick-start">docs</a>
         </div>
         <p>made by <a href="https://www.zhubert.com">zack</a> · mit license</p>
       </div>


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Remove nonexistent `demo/` package, fix `session_manager.go` location (app/ → manager/), add 9 undocumented packages, add Linear to issues/ description, fix runner map name (`claudeRunners` → `runners`), fix MCP socket path format
- **README.md**: Fix theme switching claim (no `t` shortcut exists — themes are changed via settings modal)
- **docs/index.html**: Replace removed workflow config feature card with per-repo settings, fix broken `#usage` footer anchor → `#quick-start`

## Test plan

- [ ] Verify all CLAUDE.md package paths match `internal/` directory listing
- [ ] Confirm no broken links in index.html footer
- [ ] Spot-check keyboard shortcuts in README against `shortcuts.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)